### PR TITLE
Atualização de dados para homologação.

### DIFF
--- a/exemplos/solicitarEtiquetas.php
+++ b/exemplos/solicitarEtiquetas.php
@@ -4,10 +4,12 @@ require_once __DIR__ . '/bootstrap-exemplos.php';
 $accessDataDeHomologacao = new \PhpSigep\Model\AccessDataHomologacao();
 $usuario = trim((isset($_GET['usuario']) ? $_GET['usuario'] : $accessDataDeHomologacao->getUsuario()));
 $senha = trim((isset($_GET['senha']) ? $_GET['senha'] : $accessDataDeHomologacao->getSenha()));
+$cnpjEmpresa = $accessDataDeHomologacao->getCnpjEmpresa();
 
 $accessData = new \PhpSigep\Model\AccessData();
 $accessData->setUsuario($usuario);
 $accessData->setSenha($senha);
+$accessData->setCnpjEmpresa($cnpjEmpresa);
 
 $params = new \PhpSigep\Model\SolicitaEtiquetas();
 $params->setQtdEtiquetas(1);

--- a/src/PhpSigep/Model/AccessDataHomologacao.php
+++ b/src/PhpSigep/Model/AccessDataHomologacao.php
@@ -18,9 +18,9 @@ class AccessDataHomologacao extends AccessData
                 'codAdministrativo' => '08082650',
                 'numeroContrato'    => '9912208555',
                 'cartaoPostagem'    => '0057018901',
-                'cnpjEmpresa'       => null, // Não consta no manual.
+                'cnpjEmpresa'       => '34028316000103', // Obtido no método 'buscaCliente'.
                 'anoContrato'       => null, // Não consta no manual.
-                'diretoria'         => new Diretoria(Diretoria::DIRETORIA_DR_RIO_DE_JANEIRO), // Não consta no manual, mas precisamos setar um valor para conseguir imprimir as etiquetas.
+                'diretoria'         => new Diretoria(Diretoria::DIRETORIA_DR_BRASILIA), // Obtido no método 'buscaCliente'.
             )
         );
         try {\PhpSigep\Bootstrap::getConfig()->setEnv(\PhpSigep\Config::ENV_DEVELOPMENT);} catch (\Exception $e) {}


### PR DESCRIPTION
É necessário informar o identificador no método 'solicitaEtiquetas', no ambiente de homologação, para que as etiquetas sejam retornadas. Este dado foi obtido a partir do método 'buscaCliente'.
