### PR TITLE
Fechar PreLista

### DIFF
--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -264,12 +264,11 @@ class FecharPreListaDePostagem
         foreach ($servicosAdicionais as $servicoAdicional) {
             if ($servicoAdicional->getCodigoServicoAdicional() != ServicoAdicional::SERVICE_REGISTRO) {
                 $writer->writeElement('codigo_servico_adicional', $servicoAdicional->getCodigoServicoAdicional());
-                if ($servicoAdicional->getCodigoServicoAdicional() == ServicoAdicional::SERVICE_VALOR_DECLARADO()) {
+                if ($servicoAdicional->getCodigoServicoAdicional() == ServicoAdicional::SERVICE_VALOR_DECLARADO) {
                     $writer->writeElement('valor_declarado', (float)$servicoAdicional->getValorDeclarado());
                 }
             }
         }
-        $writer->writeElement('valor_declarado');
 
         $writer->endElement();
     }


### PR DESCRIPTION
Retorna erro quando o objeto tem valor declarado.