### PR TITLE
Correção de um pequeno erro em fecharPreListaPostagem

### DIFF
--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -112,7 +112,7 @@ class FecharPreListaDePostagem
     {
         $writer->startElement('remetente');
         $writer->writeElement('numero_contrato', $data->getAccessData()->getNumeroContrato());
-        $writer->writeElement('numero_diretoria', $data->getRemetente()->getDiretoria());
+        $writer->writeElement('numero_diretoria', $data->getRemetente()->getDiretoria()->getNumero());
         $writer->writeElement('codigo_administrativo', $data->getAccessData()->getCodAdministrativo());
         $writer->startElement('nome_remetente');
         $writer->writeCData($this->_($data->getRemetente()->getNome(), 50));


### PR DESCRIPTION
Quando preenchido o campo de diretoria não era retornado o numero dentro do getDiretoria.