### PR TITLE
Peso(g) -> Peso(kg) na impressão de etiqueta

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -288,7 +288,7 @@ class CartaoDePostagem
                     $nf = '    NF: '. $nf;
                 }
 
-                $this->t($lPosChancela, 'Volume: 1/1    '.'Peso(g): ' . ((float)$objetoPostal->getPeso()) . $nf, 1, 'C',  null);
+                $this->t($lPosChancela, 'Volume: 1/1    '.'Peso(kg): ' . ((float)$objetoPostal->getPeso()) . $nf, 1, 'C',  null);
 
                 // Número da etiqueta
                 $this->setFillColor(100, 100, 200);


### PR DESCRIPTION
 O valor é expresso em kilogramas mas a legenda está em gramas.