### PR TITLE
colocando de volta PLP na etiqueta

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -41,7 +41,7 @@ class CartaoDePostagem
      */
     public function __construct($plp, $idPlpCorreios, $logoFile)
     {
-        if ($logoFile && !file_exists($logoFile)) {
+        if ($logoFile && !getimagesize($logoFile)) {
             throw new InvalidArgument('O arquivo "' . $logoFile . '" não existe.');
         }
 

--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -167,23 +167,6 @@ class CartaoDePostagem
                     $this->pdf->Image($this->logoFile, 3, 0, 25);
                 }
 
-//                // Título da etiqueta
-//                if($this->idPlpCorreios > 0) {
-//                    $lPosHeaderCol2 = $headerColWidth + $lPosFourAreas;
-//                    $this->pdf->SetXY($lPosHeaderCol2, $tPosFourAreas);
-//                    $this->setFillColor(200, 200, 200);
-//                    $this->pdf->SetFontSize(12);
-//                    $this->pdf->SetFont('', 'B');
-//                    $this->t($headerColWidth, 'Cartão de Postagem', 2, 'C');
-//
-//                    // Número da plp
-//                    $this->pdf->SetXY($lPosHeaderCol2, $tPosFourAreas + 5);
-//                    $this->setFillColor(150, 200, 200);
-//                    $this->pdf->SetFont('', '');
-//                    $this->pdf->SetFontSize(9);
-//                    $this->t($headerColWidth * 2, $this->idPlpCorreios, 0, 'C');
-//                }
-
                 // Chancela
                 $this->pdf->SetXY(66, $this->pdf->GetY() + 3);
                 $this->setFillColor(150, 150, 200);
@@ -243,6 +226,23 @@ class CartaoDePostagem
 
                 if ($chancela) {
                     $chancela->draw($this->pdf);
+                }
+
+                // Título da etiqueta
+                if($this->idPlpCorreios > 0) {
+                    $lPosHeaderCol2 = $headerColWidth + $lPosFourAreas;
+                    // $this->pdf->SetXY($lPosHeaderCol2, $tPosFourAreas);
+                    // $this->setFillColor(200, 200, 200);
+                    // $this->pdf->SetFontSize(12);
+                    // $this->pdf->SetFont('', 'B');
+                    // $this->t($headerColWidth, 'Cartão de Postagem', 2, 'C');
+
+                    // Número da plp
+                    $this->pdf->SetXY($lPosHeaderCol2, $tPosFourAreas + 32);
+                    $this->setFillColor(150, 200, 200);
+                    $this->pdf->SetFont('', '');
+                    $this->pdf->SetFontSize(9);
+                    $this->t($headerColWidth * 3, 'PLP: ' . $this->idPlpCorreios, 0, 'C');
                 }
 
                 // Volume

--- a/src/PhpSigep/Pdf/Script/BarCode128.php
+++ b/src/PhpSigep/Pdf/Script/BarCode128.php
@@ -15,9 +15,9 @@ class BarCode128
     // Set C du jeu des caract�res �ligibles
     private $Cset = "";
     // Convertisseur source des jeux vers le tableau
-    private $SetFrom;
+    private $SetFrom = array("A" => "", "B" => "");
     // Convertisseur destination des jeux vers le tableau
-    private $SetTo;
+    private $SetTo = array("A" => "", "B" => "");
     // Caract�res de s�lection de jeu au d�but du C128
     private $JStart = array("A" => 103, "B" => 104, "C" => 105);
     // Caract�res de changement de jeu


### PR DESCRIPTION
não sei exatamente pq você tinha deixado comentado a parte da PLP de aparecer na etiqueta.

Como ela só é mostrada se o parametro for >0 na chamada da classe, não vejo mal deixarmos ser possível alguém colocar essa info na etiqueta se quiser. Inclusive eu preciso :)

```php
public function __construct($plp, $idPlpCorreios, $logoFile)
```

Segue como fica a etiquta com PLP nesse PR:

![image](https://cloud.githubusercontent.com/assets/5428331/13899975/db796992-edd9-11e5-9bf3-e496bb285884.png)
