### PR TITLE
Altera Layout Etiqueta

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -287,13 +287,22 @@ class CartaoDePostagem
                     $hEtiquetaBarCode
                 );
 
+                // Nome legivel, doc e rubrica
+                // 
+                $this->pdf->SetFontSize(7);
+                $this->pdf->SetXY(1, $this->pdf->GetY() + 23);
+                $this->t(0, 'Nome Legível:___________________________________________',1, 'L',  null);
+                $this->pdf->SetXY(1, $this->pdf->GetY() + 1);
+                $this->t(0, 'Documento:_______________________Rubrica:_____________________',1, 'L',  null);
+
                 // Destinatário
                 $wAddressLeftCol = $this->pdf->w - 5;
 
-                $tPosAfterBarCode = $this->pdf->GetY() + 25;
+                $tPosAfterNameBlock = 71 ;
+
                 $t = $this->writeDestinatario(
                     $lPosFourAreas,
-                    $tPosAfterBarCode,
+                    $tPosAfterNameBlock,
                     $wAddressLeftCol,
                     $objetoPostal
                 );


### PR DESCRIPTION
Ao tentar homologar a etiqueta junto aos Correios recebi a informação abaixo:
"R.: Os Correios brevemente implantarão um serviço de imagem.  Na nova etiqueta tem um campo para assinatura e colocação de documento.  Então, será fotografado e disponibilizado para o remetente a imagem da assinatura do objeto.
Falta apenas o campo da assinatura e do documento.  OK?"

Sendo assim, adicionei os campos pedidos na etiqueta.