### PR TITLE
Permite salvar PDF gerado no Servidor

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -52,7 +52,7 @@ class CartaoDePostagem
         $this->init();
     }
 
-    public function render()
+    public function render($filename="")
     {
         $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
         if ($pdfContent = Bootstrap::getConfig()->getCacheInstance()->getItem($cacheKey)) {
@@ -62,12 +62,12 @@ class CartaoDePostagem
             header('Pragma: public');
             echo $pdfContent;
         } else {
-            $this->_render();
+            $this->_render($filename);
             Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $this->pdf->buffer);
         }
     }
 
-    private function _render()
+    private function _render($filename="")
     {
         $un = 72 / 25.4;
         $wFourAreas = $this->pdf->w;
@@ -374,7 +374,7 @@ class CartaoDePostagem
             }
         }
 
-        $this->pdf->Output();
+        $this->pdf->Output($filename);
     }
 
     private function _($str)

--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -35,7 +35,7 @@ class ListaDePostagem
         $this->init();
     }
 
-    public function render()
+    public function render($filename="")
     {
         $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
         if ($pdfContent = Bootstrap::getConfig()->getCacheInstance()->getItem($cacheKey)) {
@@ -60,7 +60,7 @@ class ListaDePostagem
             $this->writeBottom();
             $this->writeFooter();
 
-            $pdf->Output();
+            $pdf->Output($filename);
             Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $pdf->buffer);
         }
     }


### PR DESCRIPTION
Estou precisando armazenar o PDF gerado no servidor, e não fazer o output para o navegador.
Da forma como eu fiz, essa funcionalidade é totalmente opcional. Se não passar nenhum atributo o FPDF continua gerando a resposta no navegar, mas se passar um parâmetro o arquivo vai ser salvo no caminho indicado.

Deixa o pacote mais flexível, sem quebrar nada.