### PR TITLE
criando a opcao do PDF virar BUFFER e com isso poder, por exemplo, fazer upload no s3

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -41,7 +41,7 @@ class CartaoDePostagem
      */
     public function __construct($plp, $idPlpCorreios, $logoFile)
     {
-        if ($logoFile && !getimagesize($logoFile)) {
+        if ($logoFile && !@getimagesize($logoFile)) {
             throw new InvalidArgument('O arquivo "' . $logoFile . '" não existe.');
         }
 
@@ -52,7 +52,7 @@ class CartaoDePostagem
         $this->init();
     }
 
-    public function render()
+    public function render($dest='')
     {
         $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
         if ($pdfContent = Bootstrap::getConfig()->getCacheInstance()->getItem($cacheKey)) {
@@ -62,12 +62,17 @@ class CartaoDePostagem
             header('Pragma: public');
             echo $pdfContent;
         } else {
-            $this->_render();
-            Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $this->pdf->buffer);
+            if($dest == 'S'){
+                return $this->_render($dest);
+            }
+            else{
+                $this->_render($dest);
+                Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $this->pdf->buffer);
+            }
         }
     }
 
-    private function _render()
+    private function _render($dest='')
     {
         $un = 72 / 25.4;
         $wFourAreas = $this->pdf->w;
@@ -374,7 +379,12 @@ class CartaoDePostagem
             }
         }
 
-        $this->pdf->Output();
+        if($dest == 'S'){
+            return $this->pdf->Output('',$dest);
+        }
+        else{
+        $this->pdf->Output('',$dest);
+        }
     }
 
     private function _($str)

--- a/src/PhpSigep/Pdf/ImprovedFPDF.php
+++ b/src/PhpSigep/Pdf/ImprovedFPDF.php
@@ -125,7 +125,7 @@ class ImprovedFPDF extends \PhpSigepFPDF
         //Display the image contained in $data
         $v = 'img'.md5($data);
         $GLOBALS[$v] = $data;
-        $a = getimagesize('var://'.$v);
+        $a = @getimagesize('var://'.$v);
         if(!$a)
             $this->Error('Invalid image data');
         $type = substr(strstr($a['mime'],'/'),1);

--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -35,7 +35,7 @@ class ListaDePostagem
         $this->init();
     }
 
-    public function render()
+    public function render($dest='')
     {
         $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
         if ($pdfContent = Bootstrap::getConfig()->getCacheInstance()->getItem($cacheKey)) {
@@ -60,8 +60,13 @@ class ListaDePostagem
             $this->writeBottom();
             $this->writeFooter();
 
-            $pdf->Output();
-            Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $pdf->buffer);
+            if($dest == 'S'){
+               return $pdf->Output('',$dest);
+            }
+            else{
+                $pdf->Output('',$dest);
+                Bootstrap::getConfig()->getCacheInstance()->setItem($cacheKey, $pdf->buffer);
+            }
         }
     }
 


### PR DESCRIPTION
agora 'e possivel, por exemplo, mandar o PDF pro s3:

```php
            require_once __DIR__ . '/sigep/bootstrap-exemplos.php';
			$params = include __DIR__ . '/sigep/helper-criar-pre-lista.php';
			$pdf  = new \PhpSigep\Pdf\ListaDePostagem($params);
			$pdf_string = $pdf->render('S');			
			$sdk = new Aws\S3\S3Client([
			    'version'     => 'latest',
			    'region'      => 'us-east-1',
			    'credentials' => [
			        'key'    => '[key]',
			        'secret' => '[secret]',
			    ],
			]);
			$sdk->registerStreamWrapper();
			file_put_contents("s3://[bucket]/[pdf_name].pdf", $pdf_string);
```

ah, no PR tem tb um small fix pra strict