### PR TITLE
Update bootstrap-exemplos.php

### DIFF
--- a/exemplos/bootstrap-exemplos.php
+++ b/exemplos/bootstrap-exemplos.php
@@ -9,10 +9,16 @@ error_reporting(E_ALL);
 
 header('Content-Type: text/html; charset=utf-8');
 
-$autoload = __DIR__ . '/../vendor/autoload.php';
-if (file_exists($autoload)) {
-    require_once $autoload;
+$included = include file_exists(__DIR__ . '/../vendor/autoload.php') ? __DIR__ . '/../vendor/autoload.php' : __DIR__ . '/../../../autoload.php';
+
+if (!$included) {
+    echo 'You must set up the project dependencies, run the following commands:' . PHP_EOL . 'curl -sS https://getcomposer.org/installer | php' . PHP_EOL . 'php composer.phar install' . PHP_EOL;
+    
+    throw new Exception("Erro disparado a partir de __FILE__");
+
+    exit(1);
 }
+
 if (!class_exists('PhpSigepFPDF')) {
     throw new RuntimeException(
         'Não encontrei a classe PhpSigepFPDF. Execute "php composer.phar install" ou baixe o projeto ' .

--- a/exemplos/bootstrap-exemplos.php
+++ b/exemplos/bootstrap-exemplos.php
@@ -9,15 +9,27 @@ error_reporting(E_ALL);
 
 header('Content-Type: text/html; charset=utf-8');
 
-$included = include file_exists(__DIR__ . '/../vendor/autoload.php') ? __DIR__ . '/../vendor/autoload.php' : __DIR__ . '/../../../autoload.php';
+// FIX: MOZG
+
+$depth = 3;
+$path = dirname(__FILE__);
+for( $d=1 ; $d <= $depth ; $d++ ){
+    $path = dirname($path);
+}
+$vendorModuleDir = $path;
+
+$autoload_path = $vendorModuleDir . '/autoload.php';
+
+//print_r($autoload_path);
+
+$included = include $autoload_path;
 
 if (!$included) {
-    echo 'You must set up the project dependencies, run the following commands:' . PHP_EOL . 'curl -sS https://getcomposer.org/installer | php' . PHP_EOL . 'php composer.phar install' . PHP_EOL;
-    
-    throw new Exception("Erro disparado a partir de __FILE__");
-
+    echo 'Falha no carregamento do autoload';
     exit(1);
 }
+
+// FIX: MOZG
 
 if (!class_exists('PhpSigepFPDF')) {
     throw new RuntimeException(


### PR DESCRIPTION
Boa Tarde

Criei uma pasta /test

Criei um arquivo composer.json com o seguinte conteudo

	{
	   "minimum-stability": "dev",
	   "prefer-stable": true,
	   "require": {
	      "stavarengo/php-sigep": "*"
	   }
	}

No terminal executei o comando

	composer install

Foi feito o download 

  - Installing stavarengo/php-sigep-fpdf (dev-master fe32b93)
    Cloning fe32b93f484f6a3da25571d252461496bb90181f

  - Installing stavarengo/php-sigep (dev-master 579206f)
    Cloning 579206f3eefb670d30816cc7bab83efe0b7d5da8

Acessei 

http://127.0.0.1/public_html/test/vendor/stavarengo/php-sigep/exemplos/imprimirEtiquetas.php

e foi exibido o erro

	Fatal error: Uncaught RuntimeException: Não encontrei a classe PhpSigepFPDF. Execute "php composer.phar install" ou baixe o projeto https://github.com/stavarengo/php-sigep-fpdf manualmente e adicione a classe no seu path. in /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep/exemplos/bootstrap-exemplos.php:18 Stack trace: #0 /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep/exemplos/imprimirEtiquetas.php(3): require_once() #1 {main} thrown in /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep/exemplos/bootstrap-exemplos.php on line 18

Editei o arquivo

/test/vendor/stavarengo/php-sigep/exemplos/bootstrap-exemplos.php

alterando o trecho

DE

	$autoload = __DIR__ . '/../vendor/autoload.php';
	if (file_exists($autoload)) {
	    require_once $autoload;
	}

PARA

	// FIX: MOZG

	$depth = 3;
	$path = dirname(__FILE__);
	for( $d=1 ; $d <= $depth ; $d++ ){
	    $path = dirname($path);
	}
	$vendorModuleDir = $path;

	$autoload_path = $vendorModuleDir . '/autoload.php';

	//print_r($autoload_path);

	$included = include $autoload_path;

	if (!$included) {
	    echo 'Falha no carregamento do autoload';
	    exit(1);
	}

	// FIX: MOZG

Funcionou o apontamento para o autoload

Mas agora está sendo dispardo o seguinte erro

	Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; FPDF has a deprecated constructor in /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep-fpdf/fpdf.php on line 12

	Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; ReedSolomon has a deprecated constructor in /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep/src/PhpSigep/Pdf/Semacode.php on line 31

	Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Semacode has a deprecated constructor in /home/marcio/dados/public_html/test/vendor/stavarengo/php-sigep/src/PhpSigep/Pdf/Semacode.php on line 155
	FPDF error: Some data has already been output, can't send PDF file

Vejo que a biblioteca FPDF é mantida no seguinte repositório

	https://github.com/Setasign/FPDF

Porque não usar a mesma ?

A correção para o ultimo erro acima é feita trocando o nome do método por __construct