### PR TITLE
Inclusão de validação em setDiretoria na classe AccessData

### DIFF
--- a/src/PhpSigep/Model/AccessData.php
+++ b/src/PhpSigep/Model/AccessData.php
@@ -1,6 +1,8 @@
 <?php
 namespace PhpSigep\Model;
 
+use PhpSigep\InvalidArgument;
+
 /**
  * @author: Stavarengo
  */
@@ -161,10 +163,17 @@ class AccessData extends AbstractModel
     }
 
     /**
-     * @param \PhpSigep\Model\Diretoria $diretoria
+     * @param \PhpSigep\Model\Diretoria|int $diretoria
+     * @throws InvalidArgument
      */
     public function setDiretoria($diretoria)
     {
+        if (is_int($diretoria)) {
+            $diretoria = new Diretoria($diretoria);
+        }
+        if (!($diretoria instanceof Diretoria)) {
+            throw new InvalidArgument('A Diretoria deve ser ser uma instância de \PhpSigep\Model\Diretoria.');
+        }
         $this->diretoria = $diretoria;
     }
 


### PR DESCRIPTION
Se o parâmetro $diretoria for inteiro tenta criar \PhpSigep\Model\Diretoria, senão verifica se é instancia de  \PhpSigep\Model\Diretoria