### PR TITLE
Ajuste nas variáveis do Model/Dimensao e Model/ServicoAdicional

### DIFF
--- a/exemplos/helper-criar-pre-lista.php
+++ b/exemplos/helper-criar-pre-lista.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Este script cria e retorna uma instância de {@link \PhpSigep\Model\PreListaDePostagem}
- * 
+ *
  * Como existe mais de um exemplo que precisa de uma {@link \PhpSigep\Model\PreListaDePostagem}, esse script foi criado
  * para compartilhar o código necessário para a criação da {@link \PhpSigep\Model\PreListaDePostagem}.
  */
@@ -12,27 +12,30 @@
     $dimensao->setAltura(20);
     $dimensao->setLargura(20);
     $dimensao->setComprimento(20);
+    $dimensao->setDiametro(0);
     $dimensao->setTipo(\PhpSigep\Model\Dimensao::TIPO_PACOTE_CAIXA);
-    
+
     $destinatario = new \PhpSigep\Model\Destinatario();
     $destinatario->setNome('Google Belo Horizonte');
     $destinatario->setLogradouro('Av. Bias Fortes');
     $destinatario->setNumero('382');
     $destinatario->setComplemento('6º andar');
-    
+
     $destino = new \PhpSigep\Model\DestinoNacional();
     $destino->setBairro('Lourdes');
     $destino->setCep('30170-010');
     $destino->setCidade('Belo Horizonte');
     $destino->setUf('MG');
-    
-    // Estamos criando uma etique falsa, mas em um ambiente real voçê deve usar o método 
-    // {@link \PhpSigep\Services\SoapClient\Real::solicitaEtiquetas() } para gerar o número das etiquetas 
+
+    // Estamos criando uma etique falsa, mas em um ambiente real voçê deve usar o método
+    // {@link \PhpSigep\Services\SoapClient\Real::solicitaEtiquetas() } para gerar o número das etiquetas
     $etiqueta = new \PhpSigep\Model\Etiqueta();
     $etiqueta->setEtiquetaSemDv('PD73958096BR');
-    
+
     $servicoAdicional = new \PhpSigep\Model\ServicoAdicional();
     $servicoAdicional->setCodigoServicoAdicional(\PhpSigep\Model\ServicoAdicional::SERVICE_REGISTRO);
+    // Se não tiver valor declarado informar 0 (zero)
+    $servicoAdicional->setValorDeclarado(0);
 
     $encomenda = new \PhpSigep\Model\ObjetoPostal();
     $encomenda->setServicosAdicionais(array($servicoAdicional));

--- a/src/PhpSigep/Model/Dimensao.php
+++ b/src/PhpSigep/Model/Dimensao.php
@@ -7,9 +7,9 @@ namespace PhpSigep\Model;
 class Dimensao extends AbstractModel
 {
 
-    const TIPO_ENVELOPE      = 1;
-    const TIPO_PACOTE_CAIXA  = 2;
-    const TIPO_ROLO_CILINDRO = 3;
+    const TIPO_ENVELOPE      = '001';
+    const TIPO_PACOTE_CAIXA  = '002';
+    const TIPO_ROLO_CILINDRO = '003';
     /**
      * Deve ser uma das constantes {@link Dimensao}::TIPO_*.
      * @var int

--- a/src/PhpSigep/Model/ServicoAdicional.php
+++ b/src/PhpSigep/Model/ServicoAdicional.php
@@ -7,10 +7,10 @@ namespace PhpSigep\Model;
 class ServicoAdicional extends AbstractModel
 {
 
-    const SERVICE_AVISO_DE_RECEBIMENTO = 1;
-    const SERVICE_MAO_PROPRIA          = 2;
-    const SERVICE_VALOR_DECLARADO      = 19;
-    const SERVICE_REGISTRO             = 25;
+    const SERVICE_AVISO_DE_RECEBIMENTO = '001';
+    const SERVICE_MAO_PROPRIA          = '002';
+    const SERVICE_VALOR_DECLARADO      = '019';
+    const SERVICE_REGISTRO             = '025';
     /**
      * Código do serviço adicional Caractere (002) Obrigatório.
      * Uma das constantes {@link ServicoAdicional}::SERVICE_*.


### PR DESCRIPTION
Ajuste nas variáveis do Model/Dimensao e Model/ServicoAdicional para devolverem o valor com 3 dígitos e ajuste no helper-plp para adicionar o diametro() na dimensao e o valorDeclarado no ServicoAdicional

Essas alterações foram necessárias no meu caso para o Correios validarem o XML da PLP e as encomendas serem despachadas normalmente.