### PR TITLE
hotfix/metodo-rastrear-objeto

### DIFF
--- a/src/PhpSigep/Config.php
+++ b/src/PhpSigep/Config.php
@@ -9,6 +9,7 @@ use PhpSigep\Model\AccessDataHomologacao;
 
 /**
  * @author: Stavarengo
+ * @author: davidalves1
  */
 class Config extends DefaultStdClass
 {
@@ -27,6 +28,8 @@ class Config extends DefaultStdClass
 
     const WSDL_CAL_PRECO_PRAZO = 'http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx?WSDL';
 
+    const WSDL_RASTREAR_OBJETOS = 'https://webservice.correios.com.br/service/rastro/Rastro.wsdl';
+
     /**
      * Endereço para o WSDL AtendeCliente.
      * Esse WSDL possui duas versões, uma para o ambiente de produção e outra para o ambiente de desenvolvimento.
@@ -38,6 +41,11 @@ class Config extends DefaultStdClass
      * @var string
      */
     protected $wsdlCalPrecoPrazo = self::WSDL_CAL_PRECO_PRAZO;
+
+    /**
+     * @var string
+     */
+    protected $wsdlRastrearObjetos = self::WSDL_RASTREAR_OBJETOS;
 
     /**
      * @var int
@@ -170,6 +178,25 @@ class Config extends DefaultStdClass
     public function getWsdlCalcPrecoPrazo()
     {
         return $this->wsdlCalPrecoPrazo;
+    }
+
+    /**
+     * @param $wsdlRastrearObjetos
+     * @return $this
+     */
+    public function setWsdlRastrearObjetos($wsdlRastrearObjetos)
+    {
+        $this->wsdlRastrearObjetos = $wsdlRastrearObjetos;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWsdlRastrearObjetos()
+    {
+        return $this->wsdlRastrearObjetos;
     }
 
     /**

--- a/src/PhpSigep/Model/RastrearObjeto.php
+++ b/src/PhpSigep/Model/RastrearObjeto.php
@@ -3,6 +3,7 @@ namespace PhpSigep\Model;
 
 /**
  * @author: Stavarengo
+ * @author: davidalves1
  */
 class RastrearObjeto extends AbstractModel
 {

--- a/src/PhpSigep/Model/RastrearObjeto.php
+++ b/src/PhpSigep/Model/RastrearObjeto.php
@@ -23,6 +23,16 @@ class RastrearObjeto extends AbstractModel
      * O WebService vai retornar apenas o último evento dos objetos consultados. 
      */
     const TIPO_RESULTADO_APENAS_O_ULTIMO_EVENTO = 2;
+
+    /**
+     * Exibe as informações em Português do Brasil
+     */
+    const IDIOMA_PT_BR = '101';
+
+    /**
+     * Exibe as informações em Inglês
+     */
+    const IDIOMA_EN = '102';
     
     /**
      * @var AccessData
@@ -46,6 +56,12 @@ class RastrearObjeto extends AbstractModel
      * @var int
      */
     protected $tipoResultado = self::TIPO_RESULTADO_TODOS_OS_EVENTOS;
+
+    /**
+     * Define o idioma no qual as informações serão exibidas
+     * @var string
+     */
+    protected $idioma = self::IDIOMA_PT_BR;
 
     /**
      * @param \PhpSigep\Model\AccessData $accessData
@@ -132,6 +148,25 @@ class RastrearObjeto extends AbstractModel
     public function getTipoResultado()
     {
         return $this->tipoResultado;
+    }
+
+    /**
+     * @param string $idioma
+     * @return $this
+     */
+    public function setIdioma(string $idioma)
+    {
+        $this->idioma = $idioma;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdioma()
+    {
+        return $this->idioma;
     }
     
 }

--- a/src/PhpSigep/Model/RastrearObjetoEvento.php
+++ b/src/PhpSigep/Model/RastrearObjetoEvento.php
@@ -3,6 +3,7 @@ namespace PhpSigep\Model;
 
 /**
  * @author: Stavarengo
+ * @author: davidalves1
  */
 class RastrearObjetoEvento extends AbstractModel
 {
@@ -17,7 +18,11 @@ class RastrearObjetoEvento extends AbstractModel
     /**
      * @var \DateTime
      */
-    protected $dataHora;
+    protected $data;
+    /**
+     * @var \DateTime
+     */
+    protected $hora;
     /**
      * @var string
      */
@@ -25,7 +30,7 @@ class RastrearObjetoEvento extends AbstractModel
     /**
      * @var string
      */
-    protected $detalhes;
+    protected $detalhe;
     /**
      * @var string
      */
@@ -44,12 +49,12 @@ class RastrearObjetoEvento extends AbstractModel
     protected $uf;
 
     /**
-     * @param string $cidade
+     * @param string $tipo
      * @return $this;
      */
-    public function setCidade($cidade)
+    public function setTipo($tipo)
     {
-        $this->cidade = $cidade;
+        $this->tipo = $tipo;
 
         return $this;
     }
@@ -57,85 +62,9 @@ class RastrearObjetoEvento extends AbstractModel
     /**
      * @return string
      */
-    public function getCidade()
+    public function getTipo()
     {
-        return $this->cidade;
-    }
-
-    /**
-     * @param string $codigo
-     * @return $this;
-     */
-    public function setCodigo($codigo)
-    {
-        $this->codigo = $codigo;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCodigo()
-    {
-        return $this->codigo;
-    }
-
-    /**
-     * @param \DateTime $dataHora
-     * @return $this;
-     */
-    public function setDataHora(\DateTime $dataHora)
-    {
-        $this->dataHora = $dataHora;
-
-        return $this;
-    }
-
-    /**
-     * @return \DateTime
-     */
-    public function getDataHora()
-    {
-        return $this->dataHora;
-    }
-
-    /**
-     * @param string $descricao
-     * @return $this;
-     */
-    public function setDescricao($descricao)
-    {
-        $this->descricao = $descricao;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDescricao()
-    {
-        return $this->descricao;
-    }
-
-    /**
-     * @param string $local
-     * @return $this;
-     */
-    public function setLocal($local)
-    {
-        $this->local = $local;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLocal()
-    {
-        return $this->local;
+        return $this->tipo;
     }
 
     /**
@@ -158,12 +87,50 @@ class RastrearObjetoEvento extends AbstractModel
     }
 
     /**
-     * @param string $tipo
+     * @param \DateTime $data
      * @return $this;
      */
-    public function setTipo($tipo)
+    public function setData(\DateTime $data)
     {
-        $this->tipo = $tipo;
+        $this->data = $data->format('Y-m-d');
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param \DateTime $hora
+     * @return $this;
+     */
+    public function setHora(\DateTime $hora)
+    {
+        $this->hora = $hora->format('H:i');
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getHora()
+    {
+        return $this->hora;
+    }
+
+    /**
+     * @param string $descricao
+     * @return $this;
+     */
+    public function setDescricao($descricao)
+    {
+        $this->descricao = $descricao;
 
         return $this;
     }
@@ -171,10 +138,87 @@ class RastrearObjetoEvento extends AbstractModel
     /**
      * @return string
      */
-    public function getTipo()
+    public function getDescricao()
     {
-        return $this->tipo;
+        return $this->descricao;
     }
+
+    /**
+     * @param string $documento
+     * @return $this;
+     */
+    public function setDetalhe($detalhe)
+    {
+        $this->detalhe = $detalhe;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDetalhe()
+    {
+        return $this->detalhe;
+    }
+
+    /**
+     * @param string $local
+     * @return $this;
+     */
+    public function setLocal($local)
+    {
+        $this->local = $local;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocal()
+    {
+        return $this->local;
+    }
+
+    /**
+     * @param string $codigo
+     * @return $this;
+     */
+    public function setCodigo($codigo)
+    {
+        $this->codigo = $codigo;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodigo()
+    {
+        return $this->codigo;
+    }
+
+    /**
+     * @param string $cidade
+     * @return $this;
+     */
+    public function setCidade($cidade)
+    {
+        $this->cidade = $cidade;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCidade()
+    {
+        return $this->cidade;
+    }
+
 
     /**
      * @param string $uf
@@ -194,24 +238,4 @@ class RastrearObjetoEvento extends AbstractModel
     {
         return $this->uf;
     }
-
-    /**
-     * @param string $detalhes
-     * @return $this;
-     */
-    public function setDetalhes($detalhes)
-    {
-        $this->detalhes = $detalhes;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDetalhes()
-    {
-        return $this->detalhes;
-    }
-    
 }

--- a/src/PhpSigep/Services/Real/RastrearObjeto.php
+++ b/src/PhpSigep/Services/Real/RastrearObjeto.php
@@ -86,7 +86,7 @@ class RastrearObjeto
                         $evento->setData(\DateTime::createFromFormat('d/m/Y', $ev->data));
                         $evento->setHora(\DateTime::createFromFormat('H:i', $ev->hora));
                         $evento->setDescricao(SoapClientFactory::convertEncoding($ev->descricao));
-                        $evento->setDetalhe($ev->detalhe);
+                        $evento->setDetalhe(isset($ev->detalhe) ? $ev->detalhe : '');
                         $evento->setLocal($ev->local);
                         $evento->setCodigo($ev->codigo);
                         $evento->setCidade($ev->cidade);

--- a/src/PhpSigep/Services/Real/RastrearObjeto.php
+++ b/src/PhpSigep/Services/Real/RastrearObjeto.php
@@ -74,9 +74,12 @@ class RastrearObjeto
                 }
 
                 try {
-
                     $evento = new RastrearObjetoEvento();
                     $eventos = new RastrearObjetoResultado();
+
+                    if (!is_array($soapReturn->return['objeto'])) {
+                        $soapReturn->return['objeto'] = array($soapReturn->return['objeto']);
+                    }
 
                     foreach ($soapReturn->return['objeto'] as $objeto) {
                         $ev = $objeto->evento;

--- a/src/PhpSigep/Services/Real/SoapClientFactory.php
+++ b/src/PhpSigep/Services/Real/SoapClientFactory.php
@@ -23,6 +23,11 @@ class SoapClientFactory
      */
     protected static $_soapCalcPrecoPrazo;
 
+    /**
+     * @var \SoapClient
+     */
+    protected static $_soapRastrearObjetos;
+
     public static function getSoapClient()
     {
         if (!self::$_soapClient) {
@@ -58,15 +63,59 @@ class SoapClientFactory
         if (!self::$_soapCalcPrecoPrazo) {
             $wsdl = Bootstrap::getConfig()->getWsdlCalcPrecoPrazo();
 
-            self::$_soapCalcPrecoPrazo = new \SoapClient($wsdl, array(
-                "trace"              => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
-                "exceptions"         => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
-                'encoding'           => self::WEB_SERVICE_CHARSET,
-                'connection_timeout' => 60,
-            ));
+            $opts = array(
+                'ssl' => array(
+                    'ciphers'           =>'RC4-SHA',
+                    'verify_peer'       =>false,
+                    'verify_peer_name'  =>false
+                )
+            );
+            // SOAP 1.1 client
+            $params = array (
+                'encoding'              => self::WEB_SERVICE_CHARSET,
+                'verifypeer'            => false,
+                'verifyhost'            => false,
+                'soap_version'          => SOAP_1_1,
+                'trace'                 => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
+                'exceptions'            => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
+                "connection_timeout"    => 180,
+                'stream_context'        => stream_context_create($opts)
+            );
+
+            self::$_soapClient = new \SoapClient($wsdl, $params);
         }
 
         return self::$_soapCalcPrecoPrazo;
+    }
+
+    public static function getRastreioObjetos()
+    {
+        if (!self::$_soapRastrearObjetos) {
+            $wsdl = Bootstrap::getConfig()->getWsdlRastrearObjetos();
+
+            $opts = array(
+                'ssl' => array(
+                    'ciphers'           =>'RC4-SHA',
+                    'verify_peer'       =>false,
+                    'verify_peer_name'  =>false
+                )
+            );
+            // SOAP 1.1 client
+            $params = array (
+                'encoding'              => self::WEB_SERVICE_CHARSET,
+                'verifypeer'            => false,
+                'verifyhost'            => false,
+                'soap_version'          => SOAP_1_1,
+                'trace'                 => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
+                'exceptions'            => Bootstrap::getConfig()->getEnv() != Config::ENV_PRODUCTION,
+                "connection_timeout"    => 180,
+                'stream_context'        => stream_context_create($opts)
+            );
+
+            self::$_soapRastrearObjetos = new \SoapClient($wsdl, $params);
+        }
+
+        return self::$_soapRastrearObjetos;
     }
 
     /**


### PR DESCRIPTION
Correção para o método de rastreio de objetos que estava apresentando problema.

Segue exemplo de uso:

```php
$etiquetas = ['PN303013491BR', 'PJ856261967BR'];

    $new_etiquetas = [];

    foreach ($etiquetas as $etiqueta) {
        $new_etiqueta = new \PhpSigep\Model\Etiqueta();
        $new_etiqueta->setEtiquetaComDv(trim($etiqueta));
        $new_etiquetas[] = $new_etiqueta;
    }

    $access_data = new \PhpSigep\Model\AccessData();

    // Usuário e senha para teste passado no manual
    $access_data->setUsuario('ECT');
    $access_data->setSenha('SRO');

    $config = new \PhpSigep\Config();
    $config->setAccessData($access_data);
    $config->setEnv(2);
    $config->setCacheOptions([
        'storageOptions' => [
            'enabled' => false,
            'ttl' => 10,
            'cacheDir' => sys_get_temp_dir(),
        ],
    ]);

    \PhpSigep\Bootstrap::start($config);

    $params = new PhpSigep\Model\RastrearObjeto();
    $params->setAccessData($access_data);
    $params->setEtiquetas($new_etiquetas);

    $phpSigep = new PhpSigep\Services\SoapClient\Real();
    $result = $phpSigep->rastrearObjeto($params);

    print_r($result->getResult());
```