### PR TITLE
hotfix/metodo-rastrear-objeto

### DIFF
--- a/src/PhpSigep/Model/RastrearObjeto.php
+++ b/src/PhpSigep/Model/RastrearObjeto.php
@@ -133,10 +133,10 @@ class RastrearObjeto extends AbstractModel
     }
 
     /**
-     * @param mixed $tipoResultado
+     * @param int $tipoResultado
      * @return $this;
      */
-    public function setTipoResultado(mixed $tipoResultado)
+    public function setTipoResultado($tipoResultado)
     {
         $this->tipoResultado = $tipoResultado;
 

--- a/src/PhpSigep/Model/RastrearObjetoEvento.php
+++ b/src/PhpSigep/Model/RastrearObjetoEvento.php
@@ -16,7 +16,7 @@ class RastrearObjetoEvento extends AbstractModel
      */
     protected $status;
     /**
-     * @var \DateTime
+     * @var string
      */
     protected $data_hora;
     /**

--- a/src/PhpSigep/Model/RastrearObjetoEvento.php
+++ b/src/PhpSigep/Model/RastrearObjetoEvento.php
@@ -18,15 +18,15 @@ class RastrearObjetoEvento extends AbstractModel
     /**
      * @var \DateTime
      */
-    protected $data;
-    /**
-     * @var \DateTime
-     */
-    protected $hora;
+    protected $data_hora;
     /**
      * @var string
      */
     protected $descricao;
+    /**
+     * @var string
+     */
+    protected $recebedor;
     /**
      * @var string
      */
@@ -87,41 +87,22 @@ class RastrearObjetoEvento extends AbstractModel
     }
 
     /**
-     * @param \DateTime $data
+     * @param string $data_hora
      * @return $this;
      */
-    public function setData(\DateTime $data)
+    public function setDataHora(\DateTime $data_hora)
     {
-        $this->data = $data->format('Y-m-d');
+        $this->data_hora = $data_hora->format('Y-m-d H:i');
 
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return string
      */
-    public function getData()
+    public function getDataHora()
     {
-        return $this->data;
-    }
-
-    /**
-     * @param \DateTime $hora
-     * @return $this;
-     */
-    public function setHora(\DateTime $hora)
-    {
-        $this->hora = $hora->format('H:i');
-
-        return $this;
-    }
-
-    /**
-     * @return \DateTime
-     */
-    public function getHora()
-    {
-        return $this->hora;
+        return $this->data_hora;
     }
 
     /**
@@ -141,6 +122,25 @@ class RastrearObjetoEvento extends AbstractModel
     public function getDescricao()
     {
         return $this->descricao;
+    }
+
+    /**
+     * @param string $recebedor
+     * @return $this;
+     */
+    public function setRecebedor($recebedor)
+    {
+        $this->recebedor = $recebedor;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecebedor()
+    {
+        return $this->recebedor;
     }
 
     /**


### PR DESCRIPTION
### Alterações e correções:
- Após analisar novamente a documentação verifiquei que pode existir o recebedor no retorno, então foi adicionado.
- Os getter e setter de data e hora foram unificados em getDataHora e setDataHora.
- Unificar métodos de data e hora nos métodos dataHora. Incluir validação da etiqueta.
- Foi incluída a validação da etiqueta antes de adicionar o evento ao retorno.
- Foi alterado o exemplo de utilização. Segue alteração:
> Remover
```php
 var_dump($result->getResult()); 
```
> Inserir
```php
if ($result->hasError())
  var_dump($result);
else
  var_dump($result->getResult());
```