### PR TITLE
Corrigir variável onde é atribuído o retorno da chamada SOAP

### DIFF
--- a/src/PhpSigep/Services/Real/SoapClientFactory.php
+++ b/src/PhpSigep/Services/Real/SoapClientFactory.php
@@ -82,7 +82,7 @@ class SoapClientFactory
                 'stream_context'        => stream_context_create($opts)
             );
 
-            self::$_soapClient = new \SoapClient($wsdl, $params);
+            self::$_soapCalcPrecoPrazo = new \SoapClient($wsdl, $params);
         }
 
         return self::$_soapCalcPrecoPrazo;


### PR DESCRIPTION
Corrigir variável onde é atribuído o retorno da chamada SOAP no método getSoapCalcPrecoPrazo() na classe SoapClientFactory