### PR TITLE
Hotfix/rastreamento-objeto

### DIFF
--- a/src/PhpSigep/Model/RastrearObjeto.php
+++ b/src/PhpSigep/Model/RastrearObjeto.php
@@ -26,6 +26,16 @@ class RastrearObjeto extends AbstractModel
     const TIPO_RESULTADO_APENAS_O_ULTIMO_EVENTO = 2;
 
     /**
+     * Na resposta traz os resultados com erro
+     */
+    const EXIBIR_RESULTADOS_COM_ERRO = true;
+
+    /**
+     * Na resposta não traz os resultados com erro
+     */
+    const ESCONDER_RESULTADOS_COM_ERRO = false;
+
+    /**
      * Exibe as informações em Português do Brasil
      */
     const IDIOMA_PT_BR = '101';
@@ -34,7 +44,7 @@ class RastrearObjeto extends AbstractModel
      * Exibe as informações em Inglês
      */
     const IDIOMA_EN = '102';
-    
+
     /**
      * @var AccessData
      */
@@ -63,6 +73,12 @@ class RastrearObjeto extends AbstractModel
      * @var string
      */
     protected $idioma = self::IDIOMA_PT_BR;
+
+    /**
+     * Informa se no retorno deve trazer os resultados com erro ou não
+     * @var bool
+     */
+    protected $exibirErros =  self::ESCONDER_RESULTADOS_COM_ERRO;
 
     /**
      * @param \PhpSigep\Model\AccessData $accessData
@@ -168,6 +184,25 @@ class RastrearObjeto extends AbstractModel
     public function getIdioma()
     {
         return $this->idioma;
+    }
+
+    /**
+     * @param bool $exibirErros
+     * @return $this
+     */
+    public function setExibirErros(bool $exibirErros)
+    {
+        $this->exibirErros = $exibirErros;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getExibirErros()
+    {
+        return $this->exibirErros;
     }
     
 }

--- a/src/PhpSigep/Model/RastrearObjeto.php
+++ b/src/PhpSigep/Model/RastrearObjeto.php
@@ -114,7 +114,7 @@ class RastrearObjeto extends AbstractModel
 
         return $this;
     }
-    
+
     /**
      * @param \PhpSigep\Model\Etiqueta $etiqueta
      * @return $this;
@@ -190,7 +190,7 @@ class RastrearObjeto extends AbstractModel
      * @param bool $exibirErros
      * @return $this
      */
-    public function setExibirErros(bool $exibirErros)
+    public function setExibirErros($exibirErros)
     {
         $this->exibirErros = $exibirErros;
 

--- a/src/PhpSigep/Model/RastrearObjetoEvento.php
+++ b/src/PhpSigep/Model/RastrearObjetoEvento.php
@@ -47,6 +47,10 @@ class RastrearObjetoEvento extends AbstractModel
      * @var string
      */
     protected $uf;
+    /**
+     * @var string
+     */
+    protected $error;
 
     /**
      * @param string $tipo
@@ -92,7 +96,7 @@ class RastrearObjetoEvento extends AbstractModel
      */
     public function setDataHora(\DateTime $data_hora)
     {
-        $this->data_hora = $data_hora->format('Y-m-d H:i');
+        $this->dataHora = $data_hora->format('Y-m-d H:i');
 
         return $this;
     }
@@ -102,7 +106,7 @@ class RastrearObjetoEvento extends AbstractModel
      */
     public function getDataHora()
     {
-        return $this->data_hora;
+        return $this->dataHora;
     }
 
     /**
@@ -237,5 +241,24 @@ class RastrearObjetoEvento extends AbstractModel
     public function getUf()
     {
         return $this->uf;
+    }
+
+    /**
+     * @param $error
+     * @return $this
+     */
+    public function setError($error)
+    {
+        $this->error = $error;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrors()
+    {
+        return $this->error;
     }
 }

--- a/src/PhpSigep/Services/Real/RastrearObjeto.php
+++ b/src/PhpSigep/Services/Real/RastrearObjeto.php
@@ -6,7 +6,9 @@ use PhpSigep\Model\RastrearObjetoEvento;
 use PhpSigep\Model\RastrearObjetoResultado;
 use PhpSigep\Services\Real\Exception\RastrearObjeto\ExibirErrosException;
 use PhpSigep\Services\Real\Exception\RastrearObjeto\RastrearObjetoException;
+use PhpSigep\Services\Real\Exception\RastrearObjeto\TipoInvalidoException;
 use PhpSigep\Services\Result;
+use Symfony\Polyfill\Php56\Php56;
 
 /**
  * @author: Stavarengo
@@ -48,10 +50,18 @@ class RastrearObjeto
                 break;
         }
 
-        if ($params->getExibirErros())
-            $exibir_erro = true;
-        else
-            $exibir_erro = false;
+        switch ($params->getExibirErros()) {
+            case \PhpSigep\Model\RastrearObjeto::EXIBIR_RESULTADOS_COM_ERRO:
+                $exibir_erro = true;
+                break;
+            case \PhpSigep\Model\RastrearObjeto::ESCONDER_RESULTADOS_COM_ERRO:
+                $exibir_erro = false;
+                break;
+            default:
+                throw new TipoInvalidoException("Tipo '" . $params->getExibirErros(
+                    ) . "' não é válido para esta opção'");
+                break;
+        }
 
         $soapArgs = array(
             'usuario'   => $params->getAccessData()->getUsuario(),


### PR DESCRIPTION
## Descrição
Corrige problema que acontecia ao enviar várias etiquetas, descrito [nesta issue](https://github.com/stavarengo/php-sigep/issues/94 "https://github.com/stavarengo/php-sigep/issues/94") . Nesses casos, se alguma etiqueta estivesse com problema, entrava em uma exceção e parava a execução.  
Agora, ao acontecer algum problema com a etiqueta é retornado o resultado com os campos nulos e apenas o campo 'error' preenchido com o erro.

### Exemplo de configuração da exibição de erro:
```php
  // ...
  $rastrear = new PhpSigep\Model\RastrearObjeto();
  $rastrear->setAccessData($access_data);
  $rastrear->setEtiquetas($etiquetas);
  // Configura a chamada para retornar os resultados com erro
  $rastrear->setExibirErros(PhpSigep\Model\RastrearObjeto::EXIBIR_RESULTADOS_COM_ERRO);
  // ...
```
OBS: Por padrão está configurado para não exibir os resultados com erro.
### Exemplo de resposta:
```php
array (size=2)
  0 => 
    array (size=1)
      0 => 
        object(PhpSigep\Model\RastrearObjetoEvento)[112]
          protected 'tipo' => string 'PO' (length=2)
          protected 'status' => string '01' (length=2)
          protected 'dataHora' => string '2016-11-03 16:20' (length=16)
          protected 'descricao' => string 'Objeto postado' (length=14)
          protected 'recebedor' => string '' (length=0)
          protected 'detalhe' => string '' (length=0)
          protected 'local' => string 'AC TREMEMBE' (length=11)
          protected 'codigo' => string '12120970' (length=8)
          protected 'cidade' => string 'Tremembe' (length=8)
          protected 'uf' => string 'SP' (length=2)
          protected 'error' => null
          protected '_failIfAtributeNotExiste' => boolean true
  1 => 
    array (size=1)
      0 => 
        object(PhpSigep\Model\RastrearObjetoEvento)[115]
          protected 'tipo' => null
          protected 'status' => null
          protected 'dataHora' => null
          protected 'descricao' => null
          protected 'recebedor' => null
          protected 'detalhe' => null
          protected 'local' => null
          protected 'codigo' => null
          protected 'cidade' => null
          protected 'uf' => null
          protected 'error' => string '(EC310482053BR) Objeto no encontrado na base de dados dos Correios.' (length=67)
```
