### PR TITLE
Update imprimirPlp.php

### DIFF
--- a/exemplos/imprimirPlp.php
+++ b/exemplos/imprimirPlp.php
@@ -5,4 +5,4 @@ require_once __DIR__ . '/bootstrap-exemplos.php';
 $params = include __DIR__ . '/helper-criar-pre-lista.php';
 
 $pdf  = new \PhpSigep\Pdf\ListaDePostagem($params, time());
-$pdf->render($params);
+$pdf->render('I');


### PR DESCRIPTION


Bom dia

-

Veja nas imagens o passo a passo que estou usando para uso da biblioteca

-

Veja que estou usando o composer

-

Sobre o uso do exemplo "/vendor/stavarengo/php-sigep/exemplos/imprimirEtiquetas2016.php"

Na execução do exemplo via browser, vemos que é gerado erro relativo ao apontamento do autoload

Fiz a correção, alterando para a seguinte variavel

	$autoload = dirname(dirname(dirname(dirname(__FILE__)))) . '/autoload.php';

Na execução do exemplo via browser, foi gerado erro de perimissão

Fiz a correção

Na execução do exemplo via browser, foi exibido uma tela branca, onde temos o devido arquivo de etiqueta na pasta do exemplo, 

Funcionando como esperado

-

Sobre o uso do exemplo "/vendor/stavarengo/php-sigep/exemplos/imprimirPlp.php"

Na execução do exemplo via browser, vemos que é gerado o seguinte erro 


Warning: strtoupper() expects parameter 1 to be string, object given in /home/marcio/dados/public_html/test/03022017/vendor/stavarengo/php-sigep-fpdf/fpdf.php on line 988

FPDF error: Some data has already been output, can't send PDF file


-

Veja que alterei no arquivo "/vendor/stavarengo/php-sigep/exemplos/imprimirPlp.php" para

	$pdf->render('I');

Que funcionou

Tentei outra opção como

	$pdf->render('F', 'etiquetas.pdf');

Mas é gerado erro usando essa ultima

-


![animation_2017-02-03_11-26-49](https://cloud.githubusercontent.com/assets/17202780/22593264/dcda53aa-ea04-11e6-8d55-0892619b530f.gif)
