### PR TITLE
Alterar validação do código de serviço dos correios

### DIFF
--- a/src/PhpSigep/Model/SolicitaEtiquetas.php
+++ b/src/PhpSigep/Model/SolicitaEtiquetas.php
@@ -101,7 +101,7 @@ class SolicitaEtiquetas extends AbstractModel
      */
     public function setServicoDePostagem($servicoDePostagem)
     {
-        if (is_int($servicoDePostagem)) {
+        if (is_string($servicoDePostagem)) {
             $servicoDePostagem = new \PhpSigep\Model\ServicoDePostagem($servicoDePostagem);
         }
         


### PR DESCRIPTION
Alterar validação para `string`, uma vez que os códigos do serviço no Model passaram de `int` para `string`