### PR TITLE
Implementado método para retornar o XML da plp após processamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Esta API pode:
 * Gerar o relatório da PLP no formato PDF.   
 * Gerar as etiquetas de postagem no formato PDF.
 * Gerar em PDF as chancelas para cada tipo de serviço (logo de cada tipo de servico). 
+* Obter dados de PLP após postagem [processamento pelo Sara]
 
 Requisitos
 ---

--- a/src/PhpSigep/Model/SolicitaXmlPlpResult.php
+++ b/src/PhpSigep/Model/SolicitaXmlPlpResult.php
@@ -1,0 +1,93 @@
+<?php
+namespace PhpSigep\Model;
+
+/**
+ * @author: Cristiano Soares
+ * @link: http://comerciobr.com
+ */
+class SolicitaXmlPlpResult extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $tipo_arquivo;
+
+    /**
+     * @var string
+     */
+    protected $versao_arquivo;
+
+    /**
+     * @var array
+     */
+    protected $plp;
+
+    /**
+     * @var array
+     */
+    protected $remetente;
+
+    /**
+     * @var array
+     */
+    protected $forma_pagamento;
+
+    /**
+     * @var array
+     */
+    protected $objeto_postal;
+    
+    public function __construct(array $initialValues = array())
+    {
+        $this->_failIfAtributeNotExiste = false;
+        parent::__construct($initialValues);
+    }
+
+    /**
+     * @return array
+     */
+    public function getTipoArquivo()
+    {
+        return $this->tipo_arquivo;
+    }
+
+    /**
+     * @return array
+     */
+    public function getVersaoArquivo()
+    {
+        return $this->versao_arquivo;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPlp()
+    {
+        return $this->plp;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRemetente()
+    {
+        return $this->remetente;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFormaPagamento()
+    {
+        return $this->forma_pagamento;
+    }
+
+    /**
+     * @return array
+     */
+    public function getObjetoPostal()
+    {
+        return $this->objeto_postal;
+    }
+}

--- a/src/PhpSigep/Model/SolicitaXmlPlpResult.php
+++ b/src/PhpSigep/Model/SolicitaXmlPlpResult.php
@@ -36,9 +36,16 @@ class SolicitaXmlPlpResult extends AbstractModel
      * @var array
      */
     protected $objeto_postal;
+
+    /**
+     * @var array armazena o resultado bruto, caso seja necessário para outro fins
+     */
+    protected $resultArray;
     
     public function __construct(array $initialValues = array())
     {
+        $this->resultArray = $initialValues;
+
         $this->_failIfAtributeNotExiste = false;
         parent::__construct($initialValues);
     }
@@ -89,5 +96,13 @@ class SolicitaXmlPlpResult extends AbstractModel
     public function getObjetoPostal()
     {
         return $this->objeto_postal;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResultArray()
+    {
+        return $this->resultArray;
     }
 }

--- a/src/PhpSigep/Pdf/CartaoDePostagem2016.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2016.php
@@ -231,7 +231,7 @@ class CartaoDePostagem2016
 
                 switch ($servicoDePostagem->getCodigo()) {
                     case ServicoDePostagem::SERVICE_PAC_41068:
-                    case ServicoDePostagem::SERVICE_PAC_41106:
+                    case ServicoDePostagem::SERVICE_PAC_04510:
                     case ServicoDePostagem::SERVICE_PAC_CONTRATO_41211:
                     case ServicoDePostagem::SERVICE_PAC_CONTRATO_AGENCIA:
                     case ServicoDePostagem::SERVICE_PAC_GRANDES_FORMATOS:

--- a/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedConvertToArrayException.php
+++ b/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedConvertToArrayException.php
@@ -1,0 +1,10 @@
+<?php
+namespace PhpSigep\Services\Real\Exception\SolicitaXmlPlp;
+
+/**
+ * @author: Cristiano Soares
+ * @link: http://comerciobr.com
+ */
+class FailedConvertToArrayException extends \PhpSigep\Exception
+{
+}

--- a/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedConvertXmlException.php
+++ b/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedConvertXmlException.php
@@ -1,0 +1,10 @@
+<?php
+namespace PhpSigep\Services\Real\Exception\SolicitaXmlPlp;
+
+/**
+ * @author: Cristiano Soares
+ * @link: http://comerciobr.com
+ */
+class FailedConvertXmlException extends \PhpSigep\Exception
+{
+}

--- a/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedResultException.php
+++ b/src/PhpSigep/Services/Real/Exception/SolicitaXmlPlp/FailedResultException.php
@@ -1,0 +1,10 @@
+<?php
+namespace PhpSigep\Services\Real\Exception\SolicitaXmlPlp;
+
+/**
+ * @author: Cristiano Soares
+ * @link: http://comerciobr.com
+ */
+class FailedResultException extends \PhpSigep\Exception
+{
+}

--- a/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
+++ b/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
@@ -5,12 +5,15 @@ use PhpSigep\Model\SolicitaXmlPlpResult;
 use PhpSigep\Services\Exception;
 use PhpSigep\Services\Result;
 use PhpSigep\Bootstrap;
+use PhpSigep\Services\Real\Exception\SolicitaXmlPlp\FailedConvertToArrayException;
+use PhpSigep\Services\Real\Exception\SolicitaXmlPlp\FailedConvertXmlException;
+use PhpSigep\Services\Real\Exception\SolicitaXmlPlp\FailedResultException;
 
 /**
  * @author: Cristiano Soares
  * @link: http://comerciobr.com
  */
-class solicitaXmlPlp
+class SolicitaXmlPlp
 {
     /**
      * @param integer $idPlpMaster
@@ -35,7 +38,7 @@ class solicitaXmlPlp
                     throw $r;
                 }
 
-                throw new \Exception('Erro ao consultar XML da PLP. Retorno: "' . $r . '"');
+                throw new FailedResultException('Erro ao consultar XML da PLP. Retorno: "' . $r . '"');
             }
 
             if (is_string($r->return)) {
@@ -47,13 +50,13 @@ class solicitaXmlPlp
                     if ($objectToarray) {
                         $result->setResult(new SolicitaXmlPlpResult($objectToarray));
                     } else {
-                        throw new \Exception('Erro ao converter Object para Array da PLP. Retorno: "' . print_r(json_last_error_msg(), true) . '"');
+                        throw new FailedConvertToArrayException('Erro ao converter Object para Array da PLP. Retorno: "' . print_r(json_last_error_msg(), true) . '"');
                     }
                 } else {
-                    throw new \Exception('Erro ao converter XML da PLP. Retorno: "' . print_r(libxml_get_errors(), true) . '"');
+                    throw new FailedConvertXmlException('Erro ao converter XML da PLP. Retorno: "' . print_r(libxml_get_errors(), true) . '"');
                 }
             } else {
-                throw new \Exception('Erro no resultado do XML da PLP. Retorno: "' . print_r($r->return, true) . '"');
+                throw new FailedResultException('Erro no resultado do XML da PLP. Retorno: "' . print_r($r->return, true) . '"');
             }
         } catch (\Exception $e) {
             if ($e instanceof \SoapFault) {

--- a/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
+++ b/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
@@ -1,0 +1,71 @@
+<?php
+namespace PhpSigep\Services\Real;
+
+use PhpSigep\Model\SolicitaXmlPlpResult;
+use PhpSigep\Services\Exception;
+use PhpSigep\Services\Result;
+use PhpSigep\Bootstrap;
+
+/**
+ * @author: Cristiano Soares
+ * @link: http://comerciobr.com
+ */
+class solicitaXmlPlp
+{
+    /**
+     * @param integer $idPlpMaster
+     *
+     * @throws \PhpSigep\Services\Exception
+     * @return Result<SolicitaXmlPlpResult[]>
+     */
+    public function execute($idPlpMaster)
+    {
+        $soapArgs = array(
+            'idPlpMaster'   => $idPlpMaster,
+            'usuario'        => Bootstrap::getConfig()->getAccessData()->getUsuario(),
+            'senha'          => Bootstrap::getConfig()->getAccessData()->getSenha()
+        );
+
+        $result = new Result();
+
+        try {
+            $r = SoapClientFactory::getSoapClient()->solicitaXmlPlp($soapArgs);
+            if (!$r || !is_object($r) || !isset($r->return) || ($r instanceof \SoapFault)) {
+                if ($r instanceof \SoapFault) {
+                    throw $r;
+                }
+
+                throw new \Exception('Erro ao consultar XML da PLP. Retorno: "' . $r . '"');
+            }
+
+            if (is_string($r->return)) {
+                libxml_use_internal_errors(true);
+                $xml = simplexml_load_string($r->return);
+                if ($xml instanceof \SimpleXMLElement) {
+                    $objectToarray = json_decode(json_encode($xml), true);
+
+                    if ($objectToarray) {
+                        $result->setResult(new SolicitaXmlPlpResult($objectToarray));
+                    } else {
+                        throw new \Exception('Erro ao converter Object para Array da PLP. Retorno: "' . print_r(json_last_error_msg(), true) . '"');
+                    }
+                } else {
+                    throw new \Exception('Erro ao converter XML da PLP. Retorno: "' . print_r(libxml_get_errors(), true) . '"');
+                }
+            } else {
+                throw new \Exception('Erro no resultado do XML da PLP. Retorno: "' . print_r($r->return, true) . '"');
+            }
+        } catch (\Exception $e) {
+            if ($e instanceof \SoapFault) {
+                $result->setIsSoapFault(true);
+                $result->setErrorCode($e->getCode());
+                $result->setErrorMsg("Resposta do Correios: " . SoapClientFactory::convertEncoding($e->getMessage()));
+            } else {
+                $result->setErrorCode($e->getCode());
+                $result->setErrorMsg($e->getMessage());
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/PhpSigep/Services/SoapClient/Real.php
+++ b/src/PhpSigep/Services/SoapClient/Real.php
@@ -48,6 +48,18 @@ class Real implements ServiceInterface
     }
 
     /**
+     * @param integer $idPlpMaster número da PLP
+     *
+     * @return Result<\PhpSigep\Model\solicitaXmlPlp[]>
+     */
+    public function solicitaXmlPlp($idPlpMaster)
+    {
+        $service = new ServiceImplementation\solicitaXmlPlp();
+
+        return $service->execute($idPlpMaster);
+    }
+
+    /**
      * Pede para o WebService do Correios calcular o dígito verificador de uma etiqueta.
      * 
      * Se preferir você pode usar o método {@linnk \PhpSigep\Model\Etiqueta::getDv() } para calcular o dígito 


### PR DESCRIPTION
retornando Xml da PLP após a mesmo ter sido processada pelo Sara, isso é útil para o lojista salvar as informações da PLP para diversos tipos de possibilidades posteriores.