### PR TITLE
Comentando o cipher no rastreio de objetos

### DIFF
--- a/src/PhpSigep/Services/Real/SoapClientFactory.php
+++ b/src/PhpSigep/Services/Real/SoapClientFactory.php
@@ -95,7 +95,7 @@ class SoapClientFactory
 
             $opts = array(
                 'ssl' => array(
-                    'ciphers'           =>'RC4-SHA',
+                    //'ciphers'           =>'RC4-SHA',
                     'verify_peer'       =>false,
                     'verify_peer_name'  =>false
                 )


### PR DESCRIPTION
Estava apitando o warning abaixo e parou após comentário.
`PHP Warning: Uncaught ErrorException: SoapClient::SoapClient(): Failed to enable crypto in /var/www/html/.../vendor/stavarengo/php-sigep/src/PhpSigep/Services/Real/SoapClientFactory.php:115`