### PR TITLE
Adicionando LIBXML_NOCDATA

### DIFF
--- a/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
+++ b/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
@@ -43,7 +43,7 @@ class SolicitaXmlPlp
 
             if (is_string($r->return)) {
                 libxml_use_internal_errors(true);
-                $xml = simplexml_load_string($r->return);
+                $xml = simplexml_load_string($r->return, \SimpleXMLElement::class, LIBXML_NOCDATA);
                 if ($xml instanceof \SimpleXMLElement) {
                     $objectToarray = json_decode(json_encode($xml), true);
 


### PR DESCRIPTION
Adicionando LIBXML_NOCDATA na função simplexml_load_string para converter os valores com CDATA corretamente.