### PR TITLE
Adicionado ignore ao iconv

### DIFF
--- a/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
+++ b/src/PhpSigep/Services/Real/SolicitaXmlPlp.php
@@ -43,7 +43,7 @@ class SolicitaXmlPlp
 
             if (is_string($r->return)) {
                 libxml_use_internal_errors(true);
-                $xmlString = iconv('utf-8', 'ISO-8859-1', $r->return);
+                $xmlString = iconv('utf-8', 'ISO-8859-1//IGNORE', $r->return);
                 $xml = simplexml_load_string($xmlString, \SimpleXMLElement::class, LIBXML_NOCDATA);
                 if ($xml instanceof \SimpleXMLElement) {
                     $objectToarray = json_decode(json_encode($xml), true);


### PR DESCRIPTION
Processamos cerca de 20000 itens e 0,1% apresentaram alguns caracteres que o iconv não consegue converter, nesse caso adicionei o ignore para que não sejá gerada uma exceção.