### PR TITLE
Ajustes no Title do exemplo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 .buildpath
 .project
 .settings/
+src/PhpSigep/Model/AccessDataHomologacao.php

--- a/exemplos/solicitarEtiquetas.php
+++ b/exemplos/solicitarEtiquetas.php
@@ -23,7 +23,7 @@ $phpSigep = new PhpSigep\Services\SoapClient\Real();
 <html lang="pt">
     <head>
         <meta charset="UTF-8">
-        <title>Exemplo Rastrear Objetos - PHP Sigep</title>
+        <title>Exemplo de Solicitação de Etiquetas - PHP Sigep</title>
     </head>
     <body>
         <h1>Resposta</h1>

--- a/src/PhpSigep/Model/AccessDataHomologacao.php
+++ b/src/PhpSigep/Model/AccessDataHomologacao.php
@@ -23,6 +23,6 @@ class AccessDataHomologacao extends AccessData
                 'diretoria'         => new Diretoria(Diretoria::DIRETORIA_DR_BRASILIA), // Obtido no método 'buscaCliente'.
             )
         );
-        try {\PhpSigep\Bootstrap::getConfig()->setEnv(\PhpSigep\Config::ENV_DEVELOPMENT);} catch (\Exception $e) {}
+        try {\PhpSigep\Bootstrap::getConfig()->setEnv(\PhpSigep\Config::ENV_PRODUCTION);} catch (\Exception $e) {}
     }
 }


### PR DESCRIPTION
Foi ajustado o title do exemplo de solicitação de etiquetas.
Alterei o ambiente pois não autenticava no ambiente de desenvolvimento, só na produção.
Adicionado o .gitignore para os dados de acesso não serem enviados para o git.