### PR TITLE
Nova configuração do ambiente de homologação

### DIFF
--- a/src/PhpSigep/Model/AccessDataHomologacao.php
+++ b/src/PhpSigep/Model/AccessDataHomologacao.php
@@ -15,9 +15,9 @@ class AccessDataHomologacao extends AccessData
             array(
                 'usuario'           => 'sigep',
                 'senha'             => 'n5f9t8',
-                'codAdministrativo' => '08082650',
-                'numeroContrato'    => '9912208555',
-                'cartaoPostagem'    => '0057018901',
+                'codAdministrativo' => '17000190',
+                'numeroContrato'    => '9992157880',
+                'cartaoPostagem'    => '0067599079',
                 'cnpjEmpresa'       => '34028316000103', // Obtido no método 'buscaCliente'.
                 'anoContrato'       => null, // Não consta no manual.
                 'diretoria'         => new Diretoria(Diretoria::DIRETORIA_DR_BRASILIA), // Obtido no método 'buscaCliente'.


### PR DESCRIPTION
As respostas das requisições estavam vindo vazias, e vi que os dados do usuários de homologação estavam inativos e substituí pelos dados atuais do [manual dos Correios](https://www.correios.com.br/solucoes-empresariais/comercio-eletronico/palestras-correios-1/pdf/Manual_de_Implementacao_do_Web_Service_SIGEPWEB_Logistica_Reversa.pdf)