### PR TITLE
Alinhando nome e documento com destinatário no pdf de cartão de postagem

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -387,9 +387,9 @@ class CartaoDePostagem
                 // Nome legivel, doc e rubrica
                 //
                 $this->pdf->SetFontSize(7);
-                $this->pdf->SetXY(1, $this->pdf->GetY() + 23);
+                $this->pdf->SetXY(3, $this->pdf->GetY() + 23);
                 $this->t(0, 'Nome Legível:___________________________________________',1, 'L',  null);
-                $this->pdf->SetXY(1, $this->pdf->GetY() + 1);
+                $this->pdf->SetXY(3, $this->pdf->GetY() + 1);
                 $this->t(0, 'Documento:_______________________Rubrica:_____________________',1, 'L',  null);
 
                 // Destinatário

--- a/src/PhpSigep/Pdf/CartaoDePostagem2016.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2016.php
@@ -361,9 +361,9 @@ class CartaoDePostagem2016
 
                 // Nome legivel, doc e rubrica
                 $this->pdf->SetFontSize(7);
-                $this->pdf->SetXY(1, $this->pdf->GetY() + 24);
+                $this->pdf->SetXY(3, $this->pdf->GetY() + 24);
                 $this->t(0, 'Nome Legível:___________________________________________', 1, 'L',  null);
-                $this->pdf->SetXY(1, $this->pdf->GetY() + 1);
+                $this->pdf->SetXY(3, $this->pdf->GetY() + 1);
                 $this->t(0, 'Documento:______________________________________________', 1, 'L',  null);
 
                 // Destinatário
@@ -490,7 +490,7 @@ class CartaoDePostagem2016
     {
         $l = $this->pdf->GetX();
         $t1 = $this->pdf->GetY();
-        $l = 0;
+        $l = 2;
 
         $titulo = 'Destinatário';
         $nomeDestinatario = $objetoPostal->getDestinatario()->getNome();


### PR DESCRIPTION
Isso da compatibilidade com impressoras argox, tendo as mesmas configurações da etiqueta do mercado livre