### PR TITLE
Substitui utilização do substr pelo mb_substr (multi-byte safe)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.4",
         "ext-soap": "*",
+        "ext-mbstring": "*",
         "stavarengo/php-sigep-fpdf": "dev-master",
         "vria/nodiacritic": "^0.1.2"
     },

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -184,7 +184,7 @@ class FecharPreListaDePostagem
             $str = trim($str);
         }
         if ($maxLength) {
-            $str = substr($str, 0, $maxLength);
+            $str = mb_substr($str, 0, $maxLength);
         }
 
         return $str;

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -184,7 +184,7 @@ class FecharPreListaDePostagem
             $str = trim($str);
         }
         if ($maxLength) {
-            $str = mb_substr($str, 0, $maxLength);
+            $str = mb_substr($str, 0, $maxLength, 'UTF-8');
         }
 
         return $str;


### PR DESCRIPTION
O mb_substr, por ser multi-byte safe, lida corretamente com UTF-8 e evita erros de codificação no XML da PLP.

Exemplos:
```php
<?php

$str = 'éééé';

var_dump(strlen($str)); // int(8)
var_dump(mb_strlen($str)); // int(4)

$sub = substr($str, 0, 3);

var_dump($sub); // string(3) "é"
var_dump(strlen($sub)); // int(3)
var_dump(mb_strlen($sub)); // int(2)

$mb_sub = mb_substr($str, 0, 3);

var_dump($mb_sub); // string(6) "ééé"
var_dump(strlen($mb_sub)); // int(6)
var_dump(mb_strlen($mb_sub)); // int(3)
```

Repare que no `string(3) "é"`  apesar de mostrar um caractere tem um byte sobrando que causa o erro de codificação.