### PR TITLE
Permite gerar etiqueta unica

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -64,7 +64,7 @@ class CartaoDePostagem2018
 
     public function render($dest='', $filename = '')
     {
-        // $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
+        $cacheKey = md5(serialize($this->plp) . $this->idPlpCorreios . get_class($this));
         if ($pdfContent = Bootstrap::getConfig()->getCacheInstance()->getItem($cacheKey)) {
             header('Content-Type: application/pdf');
             header('Content-Disposition: inline; filename="doc.pdf"');
@@ -147,7 +147,7 @@ class CartaoDePostagem2018
                     $status_break = false;
                 }
             }
-                            
+
             if($status_continue == true){
                 continue;
             }


### PR DESCRIPTION
Melhoria para permite que possa ser passada uma unica etiqueta que deseja imprimir, não sendo necessário gerar o PDF de toda a PLP, em caso de algum erro durante a impressão, só passar o parametro etiquetaFiltro.