### PR TITLE
Mostrar peso em gramas

### DIFF
--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -298,7 +298,7 @@ class ListaDePostagem
         $pdf->SetX($xCol2);
         $pdf->CellXp($wCol2, 'CEP', 'C');
         $pdf->SetX($xCol3);
-        $pdf->CellXp($wCol3, 'Peso', 'C');
+        $pdf->CellXp($wCol3, 'Peso(g)', 'C');
         $pdf->SetX($xCol4);
         $pdf->CellXp($wCol4, 'AR', 'C');
         $pdf->SetX($xCol5);
@@ -427,7 +427,7 @@ class ListaDePostagem
                 $pdf->MultiCellXp($wCol8, $destino->getNumeroNotaFiscal(), null, 0, 'C');
             }
             $pdf->SetXY($xCol3, $y2);
-            $pdf->CellXp($wCol3, $objetoPostal->getPeso(), 'C');
+            $pdf->CellXp($wCol3, round($objetoPostal->getPeso()*1000), 'C');
             $pdf->SetX($xCol4);
             $pdf->CellXp($wCol4, ($temAr ? 'S' : 'N'), 'C');
             $pdf->SetX($xCol5);


### PR DESCRIPTION
O peso na etiqueta era exibido em gramas e aqui em kg, padronizado para mostrar em gramas.