### PR TITLE
Remover versão fixa do composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "stavarengo/php-sigep",
-    "version": "0.0.1",
     "type": "library",
     "description": "Integração com Web Service do Correios. Gera etiquetas, consulta preços e prazos, imprime etiquetas e PLP, etc.",
     "keywords": ["correios", "sigep"],


### PR DESCRIPTION
Alteração feita para poder subir as novas tags no Packagist, conforme sugerido em
https://github.com/composer/packagist/issues/649

Deve fechar a issue https://github.com/stavarengo/php-sigep/issues/306.