### PR TITLE
Melhoria Encode

### DIFF
--- a/src/PhpSigep/Config.php
+++ b/src/PhpSigep/Config.php
@@ -21,6 +21,10 @@ class Config extends DefaultStdClass
      * Indica que estamos no ambiente de desenvolvimento.
      */
     const ENV_DEVELOPMENT = 2;
+    
+    const XML_ENCODE_ISO = "iso-8859-1";
+    
+    const XML_ENCODE_UTF = "utf-8";
 
     const WSDL_ATENDE_CLIENTE_PRODUCTION = 'https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente?wsdl';
 

--- a/src/PhpSigep/Config.php
+++ b/src/PhpSigep/Config.php
@@ -176,6 +176,14 @@ class Config extends DefaultStdClass
     /**
      * @return string
      */
+    public function getXmlEncode()
+    {
+        return $this->xml_encode;
+    }    
+    
+    /**
+     * @return string
+     */
     public function getWsdlAtendeCliente()
     {
         return $this->wsdlAtendeCliente;

--- a/src/PhpSigep/Config.php
+++ b/src/PhpSigep/Config.php
@@ -63,6 +63,12 @@ class Config extends DefaultStdClass
      */
     protected $env = self::ENV_DEVELOPMENT;
 
+     /**
+     * @var string
+     */
+    protected $xml_encode = self::XML_ENCODE_UTF;
+
+    
     /**
      * @var bool
      */
@@ -152,6 +158,20 @@ class Config extends DefaultStdClass
 
         return $this;
     }
+
+    /**
+     * @param int $env
+     * @return $this
+     */
+    public function setXmlEncode($xml_encode)
+    {
+        if ($xml_encode == self::XML_ENCODE_UTF) {
+            $this->xml_encode = self::XML_ENCODE_UTF;
+        } else {
+            $this->xml_encode = self::XML_ENCODE_ISO;
+        }
+        return $this;
+    }    
 
     /**
      * @return string

--- a/src/PhpSigep/Config.php
+++ b/src/PhpSigep/Config.php
@@ -165,10 +165,10 @@ class Config extends DefaultStdClass
      */
     public function setXmlEncode($xml_encode)
     {
-        if ($xml_encode == self::XML_ENCODE_UTF) {
-            $this->xml_encode = self::XML_ENCODE_UTF;
-        } else {
+        if ($xml_encode == self::XML_ENCODE_ISO) {
             $this->xml_encode = self::XML_ENCODE_ISO;
+        } else {
+            $this->xml_encode = self::XML_ENCODE_UTF;
         }
         return $this;
     }    

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -1,6 +1,7 @@
 <?php
 namespace PhpSigep\Services\Real;
 
+use PhpSigep\Bootstrap;
 use PhpSigep\Model\Destinatario;
 use PhpSigep\Model\Destino;
 use PhpSigep\Model\DestinoInternacional;
@@ -81,7 +82,7 @@ class FecharPreListaDePostagem
         $writer->openMemory();
         $writer->setIndentString("");
         $writer->setIndent(false);
-        $writer->startDocument('1.0', 'UTF-8');
+        $writer->startDocument('1.0', Bootstrap::getConfig()->getXmlEncode());
 
         $writer->startElement('correioslog');
         $writer->writeElement('tipo_arquivo', 'Postagem');


### PR DESCRIPTION
Tentado solucionar o problema da dúvida #298 , fiz alterações para que por meio de configuração o usuário possa escolher o encode do XML que é enviado aos correios, conforme interesse, entre UTF-8 ou ISO-8859-1, como abaixo:
```
// Escolhe ISO-8859-1
$config->setXmlEncode(\PhpSigep\Config::XML_ENCODE_ISO);
```
ou
```
// Escolhe UTF-8
$config->setXmlEncode(\PhpSigep\Config::XML_ENCODE_UTF);
```

Precisando de alguma melhoria, aguardo comentários.
@andersonls  e @stavarengo Obrigado.