### PR TITLE
Diferença de dados enviados pelos Correios

### DIFF
--- a/src/PhpSigep/Services/Real/ConsultaCep.php
+++ b/src/PhpSigep/Services/Real/ConsultaCep.php
@@ -39,7 +39,7 @@ class ConsultaCep
                 $consultaCepResposta->setComplemento2(SoapClientFactory::convertEncoding($r->return->complemento2));
                 $consultaCepResposta->setEndereco(SoapClientFactory::convertEncoding($r->return->end));
                 $consultaCepResposta->setId(isset($r->return->id) ? $r->return->id  : null);
-                $consultaCepResposta->setUf($r->return->uf);//
+                $consultaCepResposta->setUf($r->return->uf);
              } else {
                  $errorCode = 0;
                  $errorMsg = "Resposta em branco. Confirme se o CEP '$cep' realmente existe.";

--- a/src/PhpSigep/Services/Real/ConsultaCep.php
+++ b/src/PhpSigep/Services/Real/ConsultaCep.php
@@ -39,7 +39,7 @@ class ConsultaCep
                 $consultaCepResposta->setComplemento2(SoapClientFactory::convertEncoding($r->return->complemento2));
                 $consultaCepResposta->setEndereco(SoapClientFactory::convertEncoding($r->return->end));
                 $consultaCepResposta->setId(isset($r->return->id) ? $r->return->id  : null);
-                $consultaCepResposta->setUf($r->return->uf);
+                $consultaCepResposta->setUf($r->return->uf);//
              } else {
                  $errorCode = 0;
                  $errorMsg = "Resposta em branco. Confirme se o CEP '$cep' realmente existe.";

--- a/src/PhpSigep/Services/Real/ConsultaCep.php
+++ b/src/PhpSigep/Services/Real/ConsultaCep.php
@@ -35,12 +35,11 @@ class ConsultaCep
                 $consultaCepResposta->setBairro(SoapClientFactory::convertEncoding($r->return->bairro));
                 $consultaCepResposta->setCep($r->return->cep);
                 $consultaCepResposta->setCidade(SoapClientFactory::convertEncoding($r->return->cidade));
-                $consultaCepResposta->setComplemento1(SoapClientFactory::convertEncoding($r->return->complemento));
+                $consultaCepResposta->setComplemento1(SoapClientFactory::convertEncoding(isset($r->return->complemento) ? $r->return->complemento  : null));
                 $consultaCepResposta->setComplemento2(SoapClientFactory::convertEncoding($r->return->complemento2));
                 $consultaCepResposta->setEndereco(SoapClientFactory::convertEncoding($r->return->end));
-                $consultaCepResposta->setId($r->return->id);
+                $consultaCepResposta->setId(isset($r->return->id) ? $r->return->id  : null);
                 $consultaCepResposta->setUf($r->return->uf);
-                $result->setResult($consultaCepResposta);
              } else {
                  $errorCode = 0;
                  $errorMsg = "Resposta em branco. Confirme se o CEP '$cep' realmente existe.";


### PR DESCRIPTION
O Método falhava porque a resposta vinda dos correios não inclui as propriedades "id" e "complemento". Com o ajuste no código, é feito um teste para verificar se as propriedades foram criadas, caso negativo coloca o valor "null". Poderíamos simplesmente comentar (ou apagar) as seguintes linhas com os métodos **setComplemento1** e **setId**, mas isso poderia impactar aplicações existentes.

Abaixo retorno que obtive, colocando um "_var_dump($r->return)_" antes da linha 34
{
    "bairro": "Imbuí"
    "cep": "41720130"
    "cidade": "Salvador"
    "complemento2": ""
    "end": "Conjunto Moradas do Imbuí"
    "uf": "BA"
  }