### PR TITLE
Envio do parametro de ValorDeclarado, independente do código do serviço adicional.

### DIFF
--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -393,16 +393,15 @@ class ListaDePostagem
             $temVd          = false;
             $valorDeclarado = null;
             foreach ($objetoPostal->getServicosAdicionais() as $servicoAdicional) {
+                $valorDeclarado = $servicoAdicional->getValorDeclarado();
                 if ($servicoAdicional->is(ServicoAdicional::SERVICE_AVISO_DE_RECEBIMENTO)) {
                     $temAr = true;
                 } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_MAO_PROPRIA)) {
                     $temMp = true;
-                } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC) || $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX)) {
-                    $temVd          = true;
-                    $valorDeclarado = $servicoAdicional->getValorDeclarado();
+                } else if ($valorDeclarado>0) {
+                    $temVd = true;
                 }
             }
-
 
             if ($i++ % 2 != 0) {
                 $fc = 225;

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -265,8 +265,8 @@ class FecharPreListaDePostagem
         foreach ($servicosAdicionais as $servicoAdicional) {
             if ($servicoAdicional->getCodigoServicoAdicional() != ServicoAdicional::SERVICE_REGISTRO) {
                 $writer->writeElement('codigo_servico_adicional', $servicoAdicional->getCodigoServicoAdicional());
-                if ($servicoAdicional->getCodigoServicoAdicional() == ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX ||
-                    $servicoAdicional->getCodigoServicoAdicional() == ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC) {
+                $valorDeclarado = (float)$servicoAdicional->getValorDeclarado();
+                if ($valorDeclarado>0) {
                     $writer->writeElement('valor_declarado', (float)$servicoAdicional->getValorDeclarado());
                 }
             }


### PR DESCRIPTION
Motivo: Os correios agora trabalha com 3 códigos de serviços que não depende do número de contrato utilizado para aquela etiqueta (019,024 e 064).
Exemplo, Ao gerar uma etiqueta para o contrato de numero 04669 (PAC), pode-se utilizar o número do código de serviço adicional 064 - National Standard. Porem este mesmo código de serviço (064) pode ser enviado quando o numero de contrato for 04332 (pac abcomm) ou 04677 (pac reverso) entre outros números.

Com esta alteração, valida-se apenas o campo positivo, ou seja, maior que 0 para o parametro "ValorDeclarado"