### PR TITLE
Alteração na etiqueta - CartaoDePostagem2018

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -253,7 +253,7 @@ class CartaoDePostagem2018
             $this->pdf->SetXY(5, 27);
             $this->pdf->SetFontSize(9);
             //$this->pdf->SetTextColor(51,51,51);
-            $nf = (int)$objetoPostal->getDestino()->getNumeroNotaFiscal();
+            $nf = $objetoPostal->getDestino()->getNumeroNotaFiscal();
             $str = $nf > 0 ?  'NF: '. $nf : ' ';
             $this->t(15, $str, 1, 'L',  null);
 

--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -314,7 +314,7 @@ class CartaoDePostagem2018
             $this->setFillColor(0, 0, 0);
             $tPosEtiquetaBarCode = $this->pdf->GetY();
 
-            $hEtiquetaBarCode = 18;
+            $hEtiquetaBarCode = 16;
             $wEtiquetaBarCode = 80;
 
             $code128 = new \PhpSigep\Pdf\Script\BarCode128();
@@ -412,7 +412,7 @@ class CartaoDePostagem2018
             $tPosCepBarCode = $t + 1;
 
             // Etiqueta do CEP
-            $hCepBarCode = 18;
+            $hCepBarCode = 16;
             $wCepBarCode = 40;
             $this->setFillColor(0, 0, 0);
             $code128 = new \PhpSigep\Pdf\Script\BarCode128();
@@ -632,12 +632,12 @@ class CartaoDePostagem2018
             // Titulo do bloco: destinatario ou remetente
             $this->pdf->SetFont('', 'B');
             $this->setFillColor(60, 60, 60);
-            $this->pdf->SetFontSize(10);
+            $this->pdf->SetFontSize(9);
             $this->pdf->SetXY(2, $t);
             $this->t($w, $titulo, 2, '');
 
             // Nome da pessoa
-            $this->pdf->SetFont('', '', 10);
+            $this->pdf->SetFont('', '', 9);
             $this->setFillColor(190, 190, 190);
             $this->pdf->SetXY(22, $t);
             $this->multiLines($w, trim($nomeDestinatario), 'L');


### PR DESCRIPTION
Reduzido o tamanho da fonte da etiqueta para que possa mostrar o destinatário e remetente com nomes grandes.
Removido a conversão para inteiro na etiqueta que estava quebrando quando a nota fiscal começa com zero a esquerda.