### PR TITLE
Campo de NF-e de 15 para 10

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -257,7 +257,7 @@ class CartaoDePostagem2018
             //$this->pdf->SetTextColor(51,51,51);
             $nf = $objetoPostal->getDestino()->getNumeroNotaFiscal();
             $str = $nf > 0 ?  'NF: '. $nf : ' ';
-            $this->t(15, $str, 1, 'L',  null);
+            $this->t(10, $str, 1, 'L',  null);
 
             // Contrato
             $AccessData = $this->plp->getAccessData();


### PR DESCRIPTION
Segundo o PR #408, onde as notas com zero a esquerda estão sendo mantidas. Foi visto que está sendo preenchido com zeros a esquerda os espaços restantes. Sendo assim, venho propor reduzir a largura de 15 para 10
![image](https://user-images.githubusercontent.com/47421207/90020484-4d5eac80-dc86-11ea-8f27-9ac2699599db.png)
