### PR TITLE
Remoção de zeros a esquerda

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -256,7 +256,7 @@ class CartaoDePostagem2018
             $this->pdf->SetFontSize(9);
             //$this->pdf->SetTextColor(51,51,51);
             $nf = $objetoPostal->getDestino()->getNumeroNotaFiscal();
-            $str = $nf > 0 ?  'NF: '. $nf : ' ';
+            $str = $nf > 0 ?  'NF: '. substr($nf,5) : ' ';
             $this->t(15, $str, 1, 'L',  null);
 
             // Contrato


### PR DESCRIPTION
Após o PR #408, foi visto que ficaram muitos zeros a esquerda, onde estava sobrepondo outras informações, após alguns testes, vendo que se deixar o preenchimento máximo de 10 caracteres fica normalizado
#### DE
![image](https://user-images.githubusercontent.com/47421207/90022024-5e102200-dc88-11ea-9e0a-e9e8d71af61d.png)
#### PARA
![image](https://user-images.githubusercontent.com/47421207/90022062-6d8f6b00-dc88-11ea-8040-a54ae9a0e172.png)
