### PR TITLE
Correção de bug na classe CircularText o for estava com 4 parametros

### DIFF
--- a/src/PhpSigep/Pdf/Script/CircularText.php
+++ b/src/PhpSigep/Pdf/Script/CircularText.php
@@ -15,7 +15,8 @@ class CircularText
         if ($fontwidth == 0) $pdf->Error('Please use values unequal to zero for font width');
         //get width of every letter
         $t = 0;
-        for ($i = 0; $iMax = strlen($text); $i < $iMax; $i++) {
+        $iMax = strlen($text);
+        for ($i = 0; $i < $iMax; $i++) {
             $w[$i] = $pdf->GetStringWidth($text[$i]);
             $w[$i] *= $kerning * $fontwidth;
             //total width of string
@@ -33,8 +34,9 @@ class CircularText
         } else {
             $transf->Rotate($pdf, -$d / 2, $x, $y);
         }
+        $iMax = strlen($text);
         //run through the string
-        for ($i = 0; $iMax = strlen($text); $i < $iMax; $i++) {
+        for ($i = 0; $i < $iMax; $i++) {
             if ($align == 'top') {
                 //rotate matrix half of the width of current letter + half of the width of preceding letter
                 if ($i == 0) {


### PR DESCRIPTION
Está dando erro  Parse error: syntax error, unexpected ';', expecting ')' in \vendor\stavarengo\php-sigep\src\PhpSigep\Pdf\Script\CircularText.php on line 18

na versão php 7.2.4 e possivelmente deve dar o mesmo erro outras versões