### PR TITLE
Caractere illegal, não imprime informações na etiqueta

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -500,7 +500,7 @@ class CartaoDePostagem2018
         $t1 = $this->pdf->GetY();
         $l = 0;
 
-        $titulo = 'DESTINATÁRIO';
+        $titulo = mb_convert_encoding('DESTINATÁRIO', 'UTF-8', 'ISO-8859-1');
         $nomeDestinatario = $objetoPostal->getDestinatario()->getNome();
         $logradouro = $objetoPostal->getDestinatario()->getLogradouro();
         $numero = $objetoPostal->getDestinatario()->getNumero();
@@ -661,7 +661,7 @@ class CartaoDePostagem2018
         }
         $this->setFillColor(100, 190, 190);
         $this->pdf->SetX($l);
-        $this->multiLines($w, $address1, 'L');
+        $$this->multiLines($w, utf8_decode($address1), 'L');
 
         //Segunda parte do endereco
         $this->pdf->SetX($l);


### PR DESCRIPTION
#### Ao receber a informação de que o endereço do cliente não estava saindo na Etiqueta nem o nome 'DESTINATÁRIO'
![image](https://user-images.githubusercontent.com/47421207/91474179-43d16900-e870-11ea-9fc7-9470d163973c.png)
#### Após aplicar o código acima
![image](https://user-images.githubusercontent.com/47421207/91474414-8f841280-e870-11ea-9977-edd1b1d5a641.png)

#### TESTES
- CAKE PHP 2.x com DEBUG[2] - Sem ocorrências
- Validação em outras etiquetas que não apresentaram problema
