### PR TITLE
Removendo classe não utilizada - Suporte Composer v2.0 

### DIFF
--- a/src/PhpSigep/Cache/InvalidAdapterException.php
+++ b/src/PhpSigep/Cache/InvalidAdapterException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PhpSigep\Cache\Storage\Adapter\Exception;
-
-class InvalidAdapterException extends \PhpSigep\Exception
-{
-}


### PR DESCRIPTION
Ao rodar o composer está mostrando esse warning, mas esta classe não está sendo usada em nenhum lugar.

`Deprecation Notice: Class PhpSigep\Cache\Storage\Adapter\Exception\InvalidAdapterException located in ./vendor/stavarengo/php-sigep/src/PhpSigep/Cache/InvalidAdapterException.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201`
