### PR TITLE
Adicionado código de carta regristrada contrato bronze

### DIFF
--- a/src/PhpSigep/Model/ServicoDePostagem.php
+++ b/src/PhpSigep/Model/ServicoDePostagem.php
@@ -64,6 +64,7 @@ class ServicoDePostagem extends AbstractModel
     // NOVOS CODIGOS DE SERVICO DOS CORREIOS BRONZE (1o sem 2020)
     const SERVICE_PAC_CONTRATO_AGENCIA_03085 = '03085';
     const SERVICE_SEDEX_CONTRATO_AGENCIA_03050 = '03050';
+    const SERVICE_CARTA_REGISTRADA_AGENCIA_80250 = '80250';
 
     protected static $services
         = array(
@@ -74,6 +75,8 @@ class ServicoDePostagem extends AbstractModel
             // NOVOS CODIGOS DE SERVICO DOS CORREIOS BRONZE (1o sem 2020)
             self::SERVICE_PAC_CONTRATO_AGENCIA_03085 => array('Pac 03085', 162011),
             self::SERVICE_SEDEX_CONTRATO_AGENCIA_03050 => array('Sedex 03050', 162008),
+            self::SERVICE_CARTA_REGISTRADA_AGENCIA_80250 => ['Carta Registrada 80250', 162142],
+
             // DEMAIS SERVICOS
             self::SERVICE_PAC_41068                                  => array('Pac 41068', 109819),
             self::SERVICE_PAC_04510                                  => array('Pac 04510', 124887),

--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -230,6 +230,7 @@ class CartaoDePostagem2018
                     break;
                 case ServicoDePostagem::SERVICE_CARTA_COMERCIAL_A_FATURAR:
                 case ServicoDePostagem::SERVICE_CARTA_REGISTRADA:
+                case ServicoDePostagem::SERVICE_CARTA_REGISTRADA_AGENCIA_80250:    
                 case ServicoDePostagem::SERVICE_CARTA_COMERCIAL_REGISTRADA_CTR_EP_MAQ_FRAN:
                 case ServicoDePostagem::SERVICE_CARTA_COM_A_FATURAR_SELO_E_SE:
                     $simbolo_de_encaminhamento = realpath(dirname(__FILE__)) . '/simbolo-sem-especificacao.png';


### PR DESCRIPTION
Adicionado código de serviço para "Carta Registrada" com contrato BRONZE nos correios.
Testado e funcionando com a impressão pelo modelo de etiqueta 2018.

Se alguém precisar adicionar de algum outro contrato (ex.: Ouro 2, Prata 1, etc) só fazer o mesmo que eu fiz com base na imagem. PS lembrar de obter o idServico correto, no buscaCliente aparece, aí basta criar uma nova entrada e colocar no lugar do 162142 e valores do 99999 aqui `self::SERVICE_CARTA_REGISTRADA_AGENCIA_99999 => ['Carta Registrada 99999', 162142],` além de adicionar no switch case do CartaoDePostagem2018

![codigos_carta](https://user-images.githubusercontent.com/2663417/110852824-9a911400-8291-11eb-8a4e-54fe564e9b94.jpeg)
