### PR TITLE
Adiciona a data de geração da PLP no PDF

### DIFF
--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -22,6 +22,10 @@ class ListaDePostagem
      * @var int
      */
     private $idPlpCorreios;
+    /**
+     * @var string
+     */
+    private $dataGeracao;
 
     /**
      * @param \PhpSigep\Model\PreListaDePostagem $plp

--- a/src/PhpSigep/Pdf/ListaDePostagem.php
+++ b/src/PhpSigep/Pdf/ListaDePostagem.php
@@ -27,10 +27,11 @@ class ListaDePostagem
      * @param \PhpSigep\Model\PreListaDePostagem $plp
      * @param int $idPlpCorreios
      */
-    public function __construct($plp, $idPlpCorreios)
+    public function __construct($plp, $idPlpCorreios, $dataGeracao = '')
     {
         $this->plp           = $plp;
         $this->idPlpCorreios = $idPlpCorreios;
+        $this->dataGeracao   = $dataGeracao;
 
         $this->init();
     }
@@ -104,6 +105,8 @@ class ListaDePostagem
 
         $pdf->setLineHeightPadding(50 / $k);
         $this->labeledText($pdf, 'Nº da lista:', $this->idPlpCorreios, $wHeaderCols);
+        if ($this->dataGeracao)
+            $this->labeledText($pdf, 'Data:', $this->dataGeracao, $wHeaderCols);
         $this->labeledText($pdf, 'Cliente:', $remetente->getNome(), $wHeaderCols, 1);
         $this->labeledText($pdf, 'Contrato:', $plp->getAccessData()->getNumeroContrato(), $wHeaderCols);
         $this->labeledText($pdf, 'Cod. adm.:', $plp->getAccessData()->getCodAdministrativo(), $wHeaderCols);


### PR DESCRIPTION
Adiciona um terceiro parâmetro não obrigatório no construtor de PhpSigep\Pdf\ListaDePostagem que se vier preenchido, é exibido entre o ID da PLP e o nome do cliente

Antes, sem a data:
![image](https://user-images.githubusercontent.com/99281/114416330-f39ce200-9b86-11eb-9b94-01805ab19733.png)

Depois, com a data:
![image](https://user-images.githubusercontent.com/99281/114416276-e4b62f80-9b86-11eb-8b3c-f0bdd2ba9bef.png)
