### PR TITLE
:bug: alterando lógica de CalcDigCep para retornar 0 ao inves de 10

### DIFF
--- a/src/PhpSigep/Pdf/CartaoDePostagem.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem.php
@@ -699,7 +699,8 @@ class CartaoDePostagem
             $sum = $sum + intval($str[$i]);
         }
         $mul = $sum - $sum % 10 + 10;
-        return $mul - $sum;
+        $digCep = ($mul - $sum)%10 == 0 ? 0 : $mul - $sum;
+        return $digCep;
     }
 
     private function getM2Dstr($cepD, $numD, $cepO, $numO, $etq, $srvA, $carP, $codS, $valD, $telD, $msg='')

--- a/src/PhpSigep/Pdf/CartaoDePostagem2016.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2016.php
@@ -674,7 +674,8 @@ class CartaoDePostagem2016
             $sum = $sum + intval($str[$i]);
         }
         $mul = $sum - $sum % 10 + 10;
-        return $mul - $sum;
+        $digCep = ($mul - $sum)%10 == 0 ? 0 : $mul - $sum;
+        return $digCep;
     }
 
     private function getM2Dstr ($cepD, $numD, $cepO, $numO, $etq, $srvA, $carP, $codS, $valD, $telD, $msg='')

--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -720,7 +720,8 @@ class CartaoDePostagem2018
             $sum = $sum + intval($str[$i]);
         }
         $mul = $sum - $sum % 10 + 10;
-        return $mul - $sum;
+        $digCep = ($mul - $sum)%10 == 0 ? 0 : $mul - $sum;
+        return $digCep;
     }
 
     private function getM2Dstr ($cepD, $numD, $cepO, $numO, $etq, $srvA, $carP, $codS, $valD, $telD, $msg='')


### PR DESCRIPTION
Na documentação dos correios, é solicitado que quando a soma dos dígitos do CEP forem igual a um múltiplo de 10, o digito verificador deve ser igual a 0. 