### PR TITLE
Mini Envios

### DIFF
--- a/src/PhpSigep/Model/ServicoAdicional.php
+++ b/src/PhpSigep/Model/ServicoAdicional.php
@@ -6,15 +6,16 @@ namespace PhpSigep\Model;
  */
 class ServicoAdicional extends AbstractModel
 {
+    const SERVICE_AVISO_DE_RECEBIMENTO          = '001';
+    const SERVICE_MAO_PROPRIA                   = '002';
+    const SERVICE_VALOR_DECLARADO_SEDEX         = '019';
+    const SERVICE_VALOR_DECLARADO_CARTA         = '035';
+    const SERVICE_VALOR_DECLARADO_PAC           = '064';
+    const SERVICE_VALOR_DECLARADO_MINI_ENVIOS   = '065';
+    const SERVICE_REGISTRO                      = '025';
 
-    const SERVICE_AVISO_DE_RECEBIMENTO  = '001';
-    const SERVICE_MAO_PROPRIA           = '002';
-    const SERVICE_VALOR_DECLARADO_SEDEX = '019';
-    const SERVICE_VALOR_DECLARADO_PAC   = '064';
-    const SERVICE_REGISTRO              = '025';
-    
     const SERVICE_VALOR_DECLARADO       = self::SERVICE_VALOR_DECLARADO_SEDEX;
-    
+
     /**
      * Código do serviço adicional Caractere (002) Obrigatório.
      * Uma das constantes {@link ServicoAdicional}::SERVICE_*.
@@ -65,6 +66,4 @@ class ServicoAdicional extends AbstractModel
     {
         return (float)$this->valorDeclarado;
     }
-
-
 }

--- a/src/PhpSigep/Model/ServicoDePostagem.php
+++ b/src/PhpSigep/Model/ServicoDePostagem.php
@@ -37,6 +37,9 @@ class ServicoDePostagem extends AbstractModel
     const SERVICE_PAC_REVERSO_CONTRATO_AGENCIA = '04677';
     const SERVICE_CARTA_COM_A_FATURAR_SELO_E_SE = '12556';
     const SERVICE_CARTA_COMERCIAL_REGISTRADA_CTR_EP_MAQ_FRAN = '10707';
+    const SERVICE_MINI_ENVIOS_04227 = '04227';
+    const SERVICE_MINI_ENVIOS_04235 = '04235';
+    const SERVICE_MINI_ENVIOS_04391 = '04391';
 
     // CODIGOS REFERENTES A LIMINAR ABCOMM
     const SERVICE_SEDEX_CONTRATO_GRANDES_FORMATOS_LM = '04146';
@@ -145,6 +148,9 @@ class ServicoDePostagem extends AbstractModel
 
             self::SERVICE_SEDEX_CONTRATO_AGENCIA_TA => array('SEDEX Contrato Agencia TA', 161274),
             self::SERVICE_PAC_CONTRATO_AGENCIA_TA   => array('PAC Contrato Agencia TA', 161277),
+            self::SERVICE_MINI_ENVIOS_04227 => array('MINI ENVIOS CTR AG', 159982),
+            self::SERVICE_MINI_ENVIOS_04235 => array('MINI ENVIOS CTR TA', 159983),
+            self::SERVICE_MINI_ENVIOS_04391 => array('MINI ENVIOS CTR UO', 160316),
         );
 
     /**
@@ -255,5 +261,4 @@ class ServicoDePostagem extends AbstractModel
     {
         $this->nome = $nome;
     }
-
 }

--- a/src/PhpSigep/Pdf/CartaoDePostagem2018.php
+++ b/src/PhpSigep/Pdf/CartaoDePostagem2018.php
@@ -240,6 +240,12 @@ class CartaoDePostagem2018
                     $simbolo_de_encaminhamento = realpath(dirname(__FILE__)) . '/simbolo-sedex-standard.png';
                     $_texto = 'SEDEX';
                     break;
+                case ServicoDePostagem::SERVICE_MINI_ENVIOS_04227:
+                case ServicoDePostagem::SERVICE_MINI_ENVIOS_04235:
+                case ServicoDePostagem::SERVICE_MINI_ENVIOS_04391:
+                    $simbolo_de_encaminhamento = realpath(dirname(__FILE__)) . '/simbolo-sem-especificacao.png';
+                    $_texto = 'Mini Envios';
+                    break;
                 default:
                     $simbolo_de_encaminhamento = null;
                     break;
@@ -346,6 +352,10 @@ class CartaoDePostagem2018
                     $valorDeclarado = $servicoAdicional->getValorDeclarado();
                 } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC)) {
                     $sSer = $sSer . "64";
+                    $_siglaAdicinal[] = "VD";
+                    $valorDeclarado = $servicoAdicional->getValorDeclarado();
+                } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_MINI_ENVIOS)) {
+                    $sSer = $sSer . "65";
                     $_siglaAdicinal[] = "VD";
                     $valorDeclarado = $servicoAdicional->getValorDeclarado();
                 } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_REGISTRO)) {

--- a/src/PhpSigep/Services/Real/CalcPrecoPrazo.php
+++ b/src/PhpSigep/Services/Real/CalcPrecoPrazo.php
@@ -56,7 +56,11 @@ class CalcPrecoPrazo
         foreach ($servicosAdicionais as $servicoAdicional) {
             if ($servicoAdicional->is(ServicoAdicional::SERVICE_MAO_PROPRIA)) {
                 $maoPropria = true;
-            } else if ($servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX) || $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC)) {
+            } elseif (
+                $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX) ||
+                $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC) ||
+                $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_MINI_ENVIOS)
+            ) {
                 if (!$servicoAdicional->getValorDeclarado()) {
                     throw new Exception('Para usar o serviço "valor declarado" é necessário declarar o valor da mercadoria.');
                 }

--- a/src/PhpSigep/Services/SoapClient/Simulador.php
+++ b/src/PhpSigep/Services/SoapClient/Simulador.php
@@ -85,7 +85,11 @@ class Simulador implements ServiceInterface
                     if ($servicoAdicional->is(ServicoAdicional::SERVICE_MAO_PROPRIA)) {
                         $valorMaoPropria = mt_rand(1, 50) / 10; // Valores entre 0.1 e 5
                     } else {
-                        if ($servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX) || $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC)) {
+                        if (
+                            $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_SEDEX) || 
+                            $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_PAC) || 
+                            $servicoAdicional->is(ServicoAdicional::SERVICE_VALOR_DECLARADO_MINI_ENVIOS)
+                        ) {
                             $valorValorDeclarado = $servicoAdicional->getValorDeclarado(
                                 ) * 1 / 100; //1% do valor declarado
                         }


### PR DESCRIPTION
- Adicionado cód. serviços para mini envios (04227, 04235, 04391).
- Adicionado serviço adicional de valor declarado para mini envios e carta.
- Adicionado mini envios na impressão de etiquetas CartaoDePostagem2018
* *Não foi adicionado chancelas para imprimir com CartaoDePostagem e CartaoDePostagem2016. 

