### PR TITLE
Adicionando e formatando o campo número de celular ao Remetente e a PLP

### DIFF
--- a/src/PhpSigep/Model/Remetente.php
+++ b/src/PhpSigep/Model/Remetente.php
@@ -91,6 +91,13 @@ class Remetente extends AbstractModel
     protected $telefone;
 
     /**
+     * Celular do remetente.
+     * Max length: 12
+     * @var string
+     */
+    protected $celular;
+
+    /**
      * Fax do remetente.
      * Max length: 12
      * @var string
@@ -325,6 +332,22 @@ class Remetente extends AbstractModel
     public function setTelefone($telefone)
     {
         $this->telefone = $telefone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCelular()
+    {
+        return $this->celular;
+    }
+
+    /**
+     * @param string $celular
+     */
+    public function setCelular($celular)
+    {
+        $this->celular = $celular;
     }
 
     /**

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -149,7 +149,7 @@ class FecharPreListaDePostagem
         $writer->writeCdata($this->_($data->getRemetente()->getEmail(), 50));
         $writer->endElement();
         $writer->startElement('celular_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCelular()), 50));
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCelular()), 12));
         $writer->endElement();
         $writer->startElement('cpf_cnpj_remetente');
         $writer->endElement();

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -149,7 +149,7 @@ class FecharPreListaDePostagem
         $writer->writeCdata($this->_($data->getRemetente()->getEmail(), 50));
         $writer->endElement();
         $writer->startElement('celular_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getTelefone(), 50));
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCelular()), 50));
         $writer->endElement();
         $writer->startElement('cpf_cnpj_remetente');
         $writer->endElement();


### PR DESCRIPTION
* Adicionando o campo número de celular ao Remetente
* Preenchendo a tag celular_remetente com o campo celular adicionado a classe Remetente
* Formatando o celular para evitar problemas com o fechamento do PLP
* corrigindo o tamanho máximo da tag celular_remetente para 12

Motivo da alteração: A tag celular_remetente estava sendo preenchida com o campo telefone e o campo não estava sendo formatado / sanitizado, ou seja, se o campo telefone contivesse um valor com parenteses ou espaços, o fechamento da PLP ocorria, mas a etiqueta estava sendo rejeitada pelo sistema dos correios após a postagem.