### PR TITLE
Demanda Correios - CPF/CNPJ obrigatórios para remessas com NF

### DIFF
--- a/src/PhpSigep/Model/Destinatario.php
+++ b/src/PhpSigep/Model/Destinatario.php
@@ -133,6 +133,13 @@ class Destinatario extends AbstractModel
     protected $ddd;
 
     /**
+     * Identificacao do destinatario (CPF/CNPJ).
+     * Max length: 14
+     * @var string
+     */
+    protected $identificacao;
+
+    /**
      * @return string
      */
     public function getCelular()
@@ -323,6 +330,23 @@ class Destinatario extends AbstractModel
     public function setDdd($ddd)
     {
         $this->ddd = $ddd;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIdentificacao()
+    {
+        return $this->identificacao;
+    }
+
+    /**
+     * @param int $identificacao
+     */
+    public function setIdentificacao($identificacao)
+    {
+        $this->identificacao = $identificacao;
         return $this;
     }
 }

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -152,6 +152,7 @@ class FecharPreListaDePostagem
         $writer->writeCdata($this->_($data->getRemetente()->getTelefone(), 50));
         $writer->endElement();
         $writer->startElement('cpf_cnpj_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getIdentificacao()), 14));
         $writer->endElement();
         $writer->writeElement('ciencia_conteudo_proibido','S');
         $writer->endElement();
@@ -224,6 +225,7 @@ class FecharPreListaDePostagem
         $writer->writeCdata($this->_($destinatario->getNumero(), 6));
         $writer->endElement();
         $writer->startElement('cpf_cnpj_destinatario');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destinatario->getIdentificacao()), 14));
         $writer->endElement();
         $writer->endElement();
     }


### PR DESCRIPTION
* Adicionado o campo identificacao ao destinatario
* Adicionado valor a tag cpf_cnpj_destinatario do destinatario e do remetente no fechamento da PLP

Motivo da alteração: Recebemos um comunicado dos Correios dizendo que a partir de 01/01/2022 o campo cpf/cnpj do destinatário será obrigatório para encomendas que acompanham nota fiscal. Esta alteração deve prover os campos necessários para cumprir com esta exigeência dos Correios.