### PR TITLE
Melhorias para PHP 8.1 e mais testes automatizados

### DIFF
--- a/exemplos/solicitarPostagemReversa.php
+++ b/exemplos/solicitarPostagemReversa.php
@@ -59,7 +59,6 @@ $remetente->setNome('Usuário Remetente');
 $remetente->setLogradouro('Avenida Vicente Machado');
 $remetente->setNumero('15');
 $remetente->setComplemento('911');
-$remetente->setReferencia('referencia de teste');
 $remetente->setCidade('Curitiba');
 $remetente->setBairro('Centro');
 $remetente->setUf('PR');
@@ -67,7 +66,6 @@ $remetente->setCep('80420010');
 
 $remetente->setEmail('teste@teste.com');
 $remetente->setIdentificacao('09941751919');
-$remetente->setSms('N');
 //$produto = new \PhpSigep\Model\Produto();
 //$produto->setCodigo(116600403);
 //$produto->setTipo(0);

--- a/src/PhpSigep/Model/Destinatario.php
+++ b/src/PhpSigep/Model/Destinatario.php
@@ -21,7 +21,7 @@ class Destinatario extends AbstractModel
      * Não Obrigatório.
      * Max length: 12
      * Tag: telefone_destinatario
-     * @var string
+     * @var string|null
      */
     protected $telefone;
 
@@ -30,7 +30,7 @@ class Destinatario extends AbstractModel
      * Não Obrigatório.
      * Max length: 12
      * Tag: celular_destinatario
-     * @var string
+     * @var string|null
      */
     protected $celular;
 
@@ -39,7 +39,7 @@ class Destinatario extends AbstractModel
      * Não obrigatório
      * Max length: 50
      * Tag: email_destinatario
-     * @var string
+     * @var string|null
      */
     protected $email;
 
@@ -57,7 +57,7 @@ class Destinatario extends AbstractModel
      * Não obrigatório.
      * Max length: 30
      * Tag: complemento_destinatario
-     * @var string
+     * @var string|null
      */
     protected $complemento;
 
@@ -92,7 +92,7 @@ class Destinatario extends AbstractModel
      * Não Obrigatório.
      * Max length: 50
      * Tag: referencia
-     * @var string
+     * @var string|null
      */
     protected $referencia;
 
@@ -119,7 +119,7 @@ class Destinatario extends AbstractModel
      * Obrigatório.
      * Max length: 8
      * Tag: cep
-     * @var int
+     * @var string
      */
     protected $cep;
 
@@ -128,19 +128,19 @@ class Destinatario extends AbstractModel
      * Não Obrigatório.
      * Max length: 3
      * Tag: ddd
-     * @var int
+     * @var int|null
      */
     protected $ddd;
 
     /**
      * Identificacao do destinatario (CPF/CNPJ).
      * Max length: 14
-     * @var string
+     * @var string|null
      */
     protected $identificacao;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCelular()
     {
@@ -156,7 +156,7 @@ class Destinatario extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getComplemento()
     {
@@ -172,7 +172,7 @@ class Destinatario extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEmail()
     {
@@ -236,7 +236,7 @@ class Destinatario extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTelefone()
     {
@@ -267,66 +267,108 @@ class Destinatario extends AbstractModel
         $this->isCliqueRetire = $isCliqueRetire;
     }
 
+    /**
+     * @return string
+     */
     public function getBairro()
     {
         return $this->bairro;
     }
 
+    /**
+     * @return string|null
+     */
     public function getReferencia()
     {
         return $this->referencia;
     }
 
+    /**
+     * @return string
+     */
     public function getCidade()
     {
         return $this->cidade;
     }
 
+    /**
+     * @return string
+     */
     public function getUf()
     {
         return $this->uf;
     }
 
+    /**
+     * @return string
+     */
     public function getCep()
     {
         return $this->cep;
     }
 
+    /**
+     * @return int|null
+     */
     public function getDdd()
     {
         return $this->ddd;
     }
 
+    /**
+     * @param string $bairro
+     * @return $this
+     */
     public function setBairro($bairro)
     {
         $this->bairro = $bairro;
         return $this;
     }
 
+    /**
+     * @param string $referencia
+     * @return $this
+     */
     public function setReferencia($referencia)
     {
         $this->referencia = $referencia;
         return $this;
     }
 
+    /**
+     * @param string $cidade
+     * @return $this
+     */
     public function setCidade($cidade)
     {
         $this->cidade = $cidade;
         return $this;
     }
 
+    /**
+     * @param string $uf
+     * @return $this
+     */
     public function setUf($uf)
     {
         $this->uf = $uf;
         return $this;
     }
 
+    /**
+     * @param string|int $cep
+     * @return $this
+     */
     public function setCep($cep)
     {
-        $this->cep = $cep;
+        $this->cep = (string)$cep;
         return $this;
     }
 
+    /**
+     * @param int|numeric-string $ddd
+     * @return $this
+     */
     public function setDdd($ddd)
     {
         $this->ddd = $ddd;
@@ -334,7 +376,7 @@ class Destinatario extends AbstractModel
     }
 
     /**
-     * @return int
+     * @return string|null
      */
     public function getIdentificacao()
     {
@@ -342,7 +384,7 @@ class Destinatario extends AbstractModel
     }
 
     /**
-     * @param int $identificacao
+     * @param int|string $identificacao
      */
     public function setIdentificacao($identificacao)
     {

--- a/src/PhpSigep/Model/Remetente.php
+++ b/src/PhpSigep/Model/Remetente.php
@@ -16,7 +16,7 @@ class Remetente extends AbstractModel
 
     /**
      * Diretoria Regional do contrato do cliente.
-     * @var Diretoria
+     * @var \PhpSigep\Model\Diretoria
      */
     protected $diretoria;
 
@@ -51,7 +51,7 @@ class Remetente extends AbstractModel
     /**
      * Complemento do endereço.
      * Max length: 20
-     * @var string
+     * @var string|null
      */
     protected $complemento;
 
@@ -86,45 +86,37 @@ class Remetente extends AbstractModel
     /**
      * Telefone do remetente.
      * Max length: 12
-     * @var string
+     * @var string|null
      */
     protected $telefone;
 
     /**
      * Celular do remetente.
      * Max length: 12
-     * @var string
+     * @var string|null
      */
     protected $celular;
 
     /**
      * Fax do remetente.
      * Max length: 12
-     * @var string
+     * @var string|null
      */
     protected $fax;
 
     /**
      * Email do remetente.
      * Max length: 50
-     * @var string
+     * @var string|null
      */
     protected $email;
 
     /**
      * Identificacao do remetente (CPF/CNPJ).
      * Max length: 14
-     * @var string
+     * @var string|null
      */
     protected $identificacao;
-
-    /**
-     * 
-     * Max length: 1
-     * @var string
-     */
-    protected $sms;
-    protected $referencia;
 
     /**
      * @return string
@@ -191,7 +183,7 @@ class Remetente extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getComplemento()
     {
@@ -223,7 +215,7 @@ class Remetente extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEmail()
     {
@@ -239,7 +231,7 @@ class Remetente extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFax()
     {
@@ -319,7 +311,7 @@ class Remetente extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTelefone()
     {
@@ -335,7 +327,7 @@ class Remetente extends AbstractModel
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCelular()
     {
@@ -366,36 +358,21 @@ class Remetente extends AbstractModel
         $this->uf = $uf;
     }
 
+    /**
+     * @return string|null
+     */
     public function getIdentificacao()
     {
         return $this->identificacao;
     }
 
-    public function getSms()
-    {
-        return $this->sms;
-    }
-
+    /**
+     * @param string $identificacao
+     * @return $this
+     */
     public function setIdentificacao($identificacao)
     {
         $this->identificacao = $identificacao;
-        return $this;
-    }
-
-    public function setSms($sms)
-    {
-        $this->sms = $sms;
-        return $this;
-    }
-
-    public function getReferencia()
-    {
-        return $this->referencia;
-    }
-
-    public function setReferencia($referencia)
-    {
-        $this->referencia = $referencia;
         return $this;
     }
 }

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -1,16 +1,9 @@
 <?php
 namespace PhpSigep\Services\Real;
 
-use PhpSigep\Bootstrap;
-use PhpSigep\Model\Destinatario;
-use PhpSigep\Model\Destino;
-use PhpSigep\Model\DestinoInternacional;
-use PhpSigep\Model\DestinoNacional;
-use PhpSigep\Model\Dimensao;
 use PhpSigep\Model\FechaPlpVariosServicosRetorno;
-use PhpSigep\Model\ObjetoPostal;
 use PhpSigep\Model\PreListaDePostagem;
-use PhpSigep\Model\ServicoAdicional;
+use PhpSigep\Services\Real\PreListaDePostagem\GerarXmlPreListaDePostagem;
 use PhpSigep\Services\Result;
 
 /**
@@ -20,26 +13,29 @@ class FecharPreListaDePostagem
 {
 
     /**
+     * @var \PhpSigep\Services\Real\PreListaDePostagem\GerarXmlPreListaDePostagem
+     */
+    private $gerarXml;
+
+    public function __construct()
+    {
+        $this->gerarXml = new GerarXmlPreListaDePostagem();
+    }
+
+    /**
      * @param PreListaDePostagem $params
      *
      * @return \PhpSigep\Services\Result<\PhpSigep\Model\FechaPlpVariosServicosRetorno>
      */
     public function execute(\PhpSigep\Model\PreListaDePostagem $params)
     {
-        $xmlDaPreLista = $this->getPlpXml($params);
-
         $listaEtiquetas = array();
         foreach ($params->getEncomendas() as $objetoPostal) {
             $listaEtiquetas[] = $objetoPostal->getEtiqueta()->getEtiquetaSemDv();
         }
 
-        $xml = $xmlDaPreLista->flush();
-        $xml = str_replace("\n",'',$xml);
-//		$xml = utf8_encode($xml);
-//		$xml = iconv('UTF-8', 'ISO-8859-1', $xml);
-
         $soapArgs = array(
-            'xml'            => $xml,
+            'xml'            => $this->gerarXml->gerar($params),
             'idPlpCliente'   => '',
             'cartaoPostagem' => $params->getAccessData()->getCartaoPostagem(),
             'listaEtiquetas' => $listaEtiquetas,
@@ -75,229 +71,5 @@ class FecharPreListaDePostagem
         }
         
         return $result;
-    }
-
-    private function getPlpXml(PreListaDePostagem $data)
-    {
-        $writer = new \XMLWriter();
-        $writer->openMemory();
-        $writer->setIndentString("");
-        $writer->setIndent(false);
-        $writer->startDocument('1.0', Bootstrap::getConfig()->getXmlEncode());
-
-        $writer->startElement('correioslog');
-        $writer->writeElement('tipo_arquivo', 'Postagem');
-        $writer->writeElement('versao_arquivo', '2.3');
-        $this->writePlp($writer, $data);
-        $this->writeRemetente($writer, $data);
-        $this->writeFormaPagamento($writer, $data);
-        foreach ($data->getEncomendas() as $objetoPostal) {
-            $this->writeObjetoPostal($writer, $objetoPostal);
-        }
-        $writer->endElement();
-
-        return $writer;
-    }
-
-    private function writePlp(\XMLWriter $writer, PreListaDePostagem $data)
-    {
-        $writer->startElement('plp');
-        $writer->writeElement('id_plp');
-        $writer->writeElement('valor_global');
-        $writer->writeElement('mcu_unidade_postagem');
-        $writer->writeElement('nome_unidade_postagem');
-        $writer->writeElement('cartao_postagem', $data->getAccessData()->getCartaoPostagem());
-        $writer->endElement();
-    }
-
-    private function writeRemetente(\XMLWriter $writer, PreListaDePostagem $data)
-    {
-        $writer->startElement('remetente');
-        $writer->writeElement('numero_contrato', $data->getAccessData()->getNumeroContrato());
-        $writer->writeElement('numero_diretoria', $data->getAccessData()->getDiretoria()->getNumero());
-        $writer->writeElement('codigo_administrativo', $data->getAccessData()->getCodAdministrativo());
-        $writer->startElement('nome_remetente');
-        $writer->writeCData($this->_($data->getRemetente()->getNome(), 50));
-        $writer->endElement();
-        $writer->startElement('logradouro_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getLogradouro(), 40));
-        $writer->endElement();
-        $writer->startElement('numero_remetente');
-        $numero_remetente = $data->getRemetente()->getNumero();
-        $writer->writeCdata($this->_(($numero_remetente ? $numero_remetente : 's/n'), 6));
-        $writer->endElement();
-        $writer->startElement('complemento_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getComplemento(), 20));
-        $writer->endElement();
-        $writer->startElement('bairro_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getBairro(), 20));
-        $writer->endElement();
-        $writer->startElement('cep_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCep()), 8));
-        $writer->endElement();
-        $writer->startElement('cidade_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getCidade(), 30));
-        $writer->endElement();
-        $writer->writeElement('uf_remetente', $this->_($data->getRemetente()->getUf(), 2, false));
-        $writer->startElement('telefone_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getTelefone()), 12));
-        $writer->endElement();
-        $writer->startElement('fax_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getFax()), 12));
-        $writer->endElement();
-        $writer->startElement('email_remetente');
-        $writer->writeCdata($this->_($data->getRemetente()->getEmail(), 50));
-        $writer->endElement();
-        $writer->startElement('celular_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCelular()), 12));
-        $writer->endElement();
-        $writer->startElement('cpf_cnpj_remetente');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getIdentificacao()), 14));
-        $writer->endElement();
-        $writer->writeElement('ciencia_conteudo_proibido','S');
-        $writer->endElement();
-    }
-
-    private function writeFormaPagamento(\XMLWriter $writer, PreListaDePostagem $data)
-    {
-        $writer->writeElement('forma_pagamento');
-    }
-
-    private function writeObjetoPostal(\XMLWriter $writer, ObjetoPostal $objetoPostal)
-    {
-        $writer->startElement('objeto_postal');
-        $writer->writeElement('numero_etiqueta', $objetoPostal->getEtiqueta()->getEtiquetaComDv());
-        $writer->writeElement('codigo_objeto_cliente');
-        $writer->writeElement('codigo_servico_postagem', $objetoPostal->getServicoDePostagem()->getCodigo());
-        $writer->writeElement('cubagem', (float)$objetoPostal->getCubagem());
-        $writer->writeElement('peso', (float)$objetoPostal->getPeso() * 1000);
-        $writer->writeElement('rt1');
-        $writer->writeElement('rt2');
-        $writer->writeElement('restricao_anac', 0);
-        $this->writeDestinatario($writer, $objetoPostal->getDestinatario());
-        $this->writeDestino($writer, $objetoPostal->getDestino());
-        $this->writeServicoAdicional($writer, (array)$objetoPostal->getServicosAdicionais());
-        $this->writeDimensaoObjeto($writer, $objetoPostal->getDimensao());
-        $writer->writeElement('data_postagem_sara');
-        $writer->writeElement('status_processamento', 0);
-        $writer->writeElement('numero_comprovante_postagem');
-        $writer->writeElement('valor_cobrado');
-        $writer->endElement();
-    }
-
-    private function _($str, $maxLength, $cdata = true, $trim = true)
-    {
-        if ($str === null) {
-            return $str;
-        }
-        if ($trim) {
-            $str = trim($str);
-        }
-        if ($maxLength) {
-            $str = mb_substr($str, 0, $maxLength, 'UTF-8');
-        }
-
-        return $str;
-    }
-
-    private function writeDestinatario(\XMLWriter $writer, Destinatario $destinatario)
-    {
-        $writer->startElement('destinatario');
-        $writer->startElement('nome_destinatario');
-        $writer->writeCdata($this->_($destinatario->getNome(), 50));
-        $writer->endElement();
-        $writer->startElement('telefone_destinatario');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destinatario->getTelefone()), 12));
-        $writer->endElement();
-        $writer->startElement('celular_destinatario');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destinatario->getCelular()), 12));
-        $writer->endElement();
-        $writer->startElement('email_destinatario');
-        $writer->writeCdata($this->_($destinatario->getEmail(), 50));
-        $writer->endElement();
-        $writer->startElement('logradouro_destinatario');
-        $writer->writeCdata($this->_($destinatario->getLogradouro(), 50));
-        $writer->endElement();
-        $writer->startElement('complemento_destinatario');
-        $writer->writeCdata($this->_($destinatario->getComplemento(), 30));
-        $writer->endElement();
-        $writer->startElement('numero_end_destinatario');
-        $writer->writeCdata($this->_($destinatario->getNumero(), 6));
-        $writer->endElement();
-        $writer->startElement('cpf_cnpj_destinatario');
-        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destinatario->getIdentificacao()), 14));
-        $writer->endElement();
-        $writer->endElement();
-    }
-
-    private function writeDestino(\XMLWriter $writer, Destino $destino)
-    {
-        if ($destino instanceof DestinoNacional) {
-            $writer->startElement('nacional');
-            $writer->startElement('bairro_destinatario');
-            $writer->writeCdata($this->_($destino->getBairro(), 30));
-            $writer->endElement();
-            $writer->startElement('cidade_destinatario');
-            $writer->writeCdata($this->_($destino->getCidade(), 30));
-            $writer->endElement();
-            $writer->writeElement('uf_destinatario', $this->_($destino->getUf(), 2, false));
-            $writer->startElement('cep_destinatario');
-            $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destino->getCep()), 8));
-            $writer->endElement();
-            $writer->writeElement('codigo_usuario_postal');
-            $writer->writeElement('centro_custo_cliente');
-            $writer->writeElement('numero_nota_fiscal', $destino->getNumeroNotaFiscal());
-            $writer->writeElement('serie_nota_fiscal', $this->_($destino->getSerieNotaFiscal(), 20));
-            $writer->writeElement('valor_nota_fiscal', $destino->getValorNotaFiscal());
-            $writer->writeElement('natureza_nota_fiscal', $this->_($destino->getNaturezaNotaFiscal(), 20));
-            $writer->startElement('descricao_objeto');
-            $writer->writeCdata($this->_($destino->getDescricaoObjeto(), 20));
-            $writer->endElement();
-            $writer->writeElement('valor_a_cobrar', (float)$destino->getValorACobrar());
-            $writer->endElement();
-        } else {
-            if ($destino instanceof DestinoInternacional) {
-                $writer->startElement('internacional');
-                $writer->endElement();
-            }
-        }
-    }
-
-    /**
-     * @param \XMLWriter $writer
-     * @param ServicoAdicional[] $servicosAdicionais
-     */
-    private function writeServicoAdicional(\XMLWriter $writer, array $servicosAdicionais)
-    {
-        $writer->startElement('servico_adicional');
-
-        // De acordo com o manual este serviço é obrigatório 
-        $writer->writeElement('codigo_servico_adicional', ServicoAdicional::SERVICE_REGISTRO);
-
-        foreach ($servicosAdicionais as $servicoAdicional) {
-            if ($servicoAdicional->getCodigoServicoAdicional() != ServicoAdicional::SERVICE_REGISTRO) {
-                $writer->writeElement('codigo_servico_adicional', $servicoAdicional->getCodigoServicoAdicional());
-                $valorDeclarado = (float)$servicoAdicional->getValorDeclarado();
-                if ($valorDeclarado>0) {
-                    $writer->writeElement('valor_declarado', (float)$servicoAdicional->getValorDeclarado());
-                }
-            }
-        }
-        $writer->endElement();
-    }
-
-    private function writeDimensaoObjeto(\XMLWriter $writer, Dimensao $dimensao)
-    {
-        $writer->startElement('dimensao_objeto');
-        $writer->writeElement('tipo_objeto', $dimensao->getTipo());
-        $writer->writeElement('dimensao_altura', $dimensao->getAltura());
-        $writer->writeElement('dimensao_largura', $dimensao->getLargura());
-        $writer->writeElement('dimensao_comprimento', $dimensao->getComprimento());
-        if (!$dimensao->getDiametro()) {
-            $writer->writeElement('dimensao_diametro', 0);
-        } else {
-            $writer->writeElement('dimensao_diametro', $dimensao->getDiametro());
-        }
-        $writer->endElement();
     }
 }

--- a/src/PhpSigep/Services/Real/PreListaDePostagem/GerarXmlPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/PreListaDePostagem/GerarXmlPreListaDePostagem.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace PhpSigep\Services\Real\PreListaDePostagem;
+
+use PhpSigep\Bootstrap;
+use PhpSigep\Model\Destinatario;
+use PhpSigep\Model\Destino;
+use PhpSigep\Model\DestinoInternacional;
+use PhpSigep\Model\DestinoNacional;
+use PhpSigep\Model\Dimensao;
+use PhpSigep\Model\ObjetoPostal;
+use PhpSigep\Model\PreListaDePostagem;
+use PhpSigep\Model\ServicoAdicional;
+
+class GerarXmlPreListaDePostagem
+{
+    public function gerar(PreListaDePostagem $params) {
+        $xmlDaPreLista = $this->getPlpXml($params);
+        $xml = $xmlDaPreLista->flush();
+        return str_replace("\n",'',$xml);
+    }
+
+    private function getPlpXml(PreListaDePostagem $data)
+    {
+        $writer = new \XMLWriter();
+        $writer->openMemory();
+        $writer->setIndentString("");
+        $writer->setIndent(false);
+        $writer->startDocument('1.0', Bootstrap::getConfig()->getXmlEncode());
+
+        $writer->startElement('correioslog');
+        $writer->writeElement('tipo_arquivo', 'Postagem');
+        $writer->writeElement('versao_arquivo', '2.3');
+        $this->writePlp($writer, $data);
+        $this->writeRemetente($writer, $data);
+        $this->writeFormaPagamento($writer, $data);
+        foreach ($data->getEncomendas() as $objetoPostal) {
+            $this->writeObjetoPostal($writer, $objetoPostal);
+        }
+        $writer->endElement();
+
+        return $writer;
+    }
+
+    private function writePlp(\XMLWriter $writer, PreListaDePostagem $data)
+    {
+        $writer->startElement('plp');
+        $writer->writeElement('id_plp');
+        $writer->writeElement('valor_global');
+        $writer->writeElement('mcu_unidade_postagem');
+        $writer->writeElement('nome_unidade_postagem');
+        $writer->writeElement('cartao_postagem', $data->getAccessData()->getCartaoPostagem());
+        $writer->endElement();
+    }
+
+    private function writeRemetente(\XMLWriter $writer, PreListaDePostagem $data)
+    {
+        $writer->startElement('remetente');
+        $writer->writeElement('numero_contrato', $data->getAccessData()->getNumeroContrato());
+        $writer->writeElement('numero_diretoria', $data->getAccessData()->getDiretoria()->getNumero());
+        $writer->writeElement('codigo_administrativo', $data->getAccessData()->getCodAdministrativo());
+        $writer->startElement('nome_remetente');
+        $writer->writeCData($this->_($data->getRemetente()->getNome(), 50));
+        $writer->endElement();
+        $writer->startElement('logradouro_remetente');
+        $writer->writeCdata($this->_($data->getRemetente()->getLogradouro(), 40));
+        $writer->endElement();
+        $writer->startElement('numero_remetente');
+        $numero_remetente = $data->getRemetente()->getNumero();
+        $writer->writeCdata($this->_(($numero_remetente ? $numero_remetente : 's/n'), 6));
+        $writer->endElement();
+        $writer->startElement('complemento_remetente');
+        $writer->writeCdata($this->_($data->getRemetente()->getComplemento(), 20));
+        $writer->endElement();
+        $writer->startElement('bairro_remetente');
+        $writer->writeCdata($this->_($data->getRemetente()->getBairro(), 20));
+        $writer->endElement();
+        $writer->startElement('cep_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getCep()), 8));
+        $writer->endElement();
+        $writer->startElement('cidade_remetente');
+        $writer->writeCdata($this->_($data->getRemetente()->getCidade(), 30));
+        $writer->endElement();
+        $writer->writeElement('uf_remetente', $this->_($data->getRemetente()->getUf(), 2, false));
+        $writer->startElement('telefone_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$data->getRemetente()->getTelefone()), 12));
+        $writer->endElement();
+        $writer->startElement('fax_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$data->getRemetente()->getFax()), 12));
+        $writer->endElement();
+        $writer->startElement('email_remetente');
+        $writer->writeCdata($this->_($data->getRemetente()->getEmail(), 50));
+        $writer->endElement();
+        $writer->startElement('celular_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$data->getRemetente()->getCelular()), 12));
+        $writer->endElement();
+        $writer->startElement('cpf_cnpj_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$data->getRemetente()->getIdentificacao()), 14));
+        $writer->endElement();
+        $writer->writeElement('ciencia_conteudo_proibido','S');
+        $writer->endElement();
+    }
+
+    private function writeFormaPagamento(\XMLWriter $writer, PreListaDePostagem $data)
+    {
+        $writer->writeElement('forma_pagamento');
+    }
+
+    private function writeObjetoPostal(\XMLWriter $writer, ObjetoPostal $objetoPostal)
+    {
+        $writer->startElement('objeto_postal');
+        $writer->writeElement('numero_etiqueta', $objetoPostal->getEtiqueta()->getEtiquetaComDv());
+        $writer->writeElement('codigo_objeto_cliente');
+        $writer->writeElement('codigo_servico_postagem', $objetoPostal->getServicoDePostagem()->getCodigo());
+        $writer->writeElement('cubagem', (float)$objetoPostal->getCubagem());
+        $writer->writeElement('peso', (float)$objetoPostal->getPeso() * 1000);
+        $writer->writeElement('rt1');
+        $writer->writeElement('rt2');
+        $writer->writeElement('restricao_anac', 0);
+        $this->writeDestinatario($writer, $objetoPostal->getDestinatario());
+        $this->writeDestino($writer, $objetoPostal->getDestino());
+        $this->writeServicoAdicional($writer, (array)$objetoPostal->getServicosAdicionais());
+        $this->writeDimensaoObjeto($writer, $objetoPostal->getDimensao());
+        $writer->writeElement('data_postagem_sara');
+        $writer->writeElement('status_processamento', 0);
+        $writer->writeElement('numero_comprovante_postagem');
+        $writer->writeElement('valor_cobrado');
+        $writer->endElement();
+    }
+
+    private function _($str, $maxLength, $cdata = true, $trim = true)
+    {
+        if ($str === null) {
+            return "";
+        }
+        if ($trim) {
+            $str = trim($str);
+        }
+        if ($maxLength) {
+            $str = mb_substr($str, 0, $maxLength, 'UTF-8');
+        }
+
+        return $str;
+    }
+
+    private function writeDestinatario(\XMLWriter $writer, Destinatario $destinatario)
+    {
+        $writer->startElement('destinatario');
+        $writer->startElement('nome_destinatario');
+        $writer->writeCdata($this->_($destinatario->getNome(), 50));
+        $writer->endElement();
+        $writer->startElement('telefone_destinatario');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$destinatario->getTelefone()), 12));
+        $writer->endElement();
+        $writer->startElement('celular_destinatario');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$destinatario->getCelular()), 12));
+        $writer->endElement();
+        $writer->startElement('email_destinatario');
+        $writer->writeCdata($this->_($destinatario->getEmail(), 50));
+        $writer->endElement();
+        $writer->startElement('logradouro_destinatario');
+        $writer->writeCdata($this->_($destinatario->getLogradouro(), 50));
+        $writer->endElement();
+        $writer->startElement('complemento_destinatario');
+        $writer->writeCdata($this->_($destinatario->getComplemento(), 30));
+        $writer->endElement();
+        $writer->startElement('numero_end_destinatario');
+        $writer->writeCdata($this->_($destinatario->getNumero(), 6));
+        $writer->endElement();
+        $writer->startElement('cpf_cnpj_destinatario');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', (string)$destinatario->getIdentificacao()), 14));
+        $writer->endElement();
+        $writer->endElement();
+    }
+
+    private function writeDestino(\XMLWriter $writer, Destino $destino)
+    {
+        if ($destino instanceof DestinoNacional) {
+            $writer->startElement('nacional');
+            $writer->startElement('bairro_destinatario');
+            $writer->writeCdata($this->_($destino->getBairro(), 30));
+            $writer->endElement();
+            $writer->startElement('cidade_destinatario');
+            $writer->writeCdata($this->_($destino->getCidade(), 30));
+            $writer->endElement();
+            $writer->writeElement('uf_destinatario', $this->_($destino->getUf(), 2, false));
+            $writer->startElement('cep_destinatario');
+            $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destino->getCep()), 8));
+            $writer->endElement();
+            $writer->writeElement('codigo_usuario_postal');
+            $writer->writeElement('centro_custo_cliente');
+            $writer->writeElement('numero_nota_fiscal', $destino->getNumeroNotaFiscal());
+            $writer->writeElement('serie_nota_fiscal', $this->_($destino->getSerieNotaFiscal(), 20));
+            $writer->writeElement('valor_nota_fiscal', $destino->getValorNotaFiscal());
+            $writer->writeElement('natureza_nota_fiscal', $this->_($destino->getNaturezaNotaFiscal(), 20));
+            $writer->startElement('descricao_objeto');
+            $writer->writeCdata($this->_($destino->getDescricaoObjeto(), 20));
+            $writer->endElement();
+            $writer->writeElement('valor_a_cobrar', (float)$destino->getValorACobrar());
+            $writer->endElement();
+        } else {
+            if ($destino instanceof DestinoInternacional) {
+                $writer->startElement('internacional');
+                $writer->endElement();
+            }
+        }
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @param ServicoAdicional[] $servicosAdicionais
+     */
+    private function writeServicoAdicional(\XMLWriter $writer, array $servicosAdicionais)
+    {
+        $writer->startElement('servico_adicional');
+
+        // De acordo com o manual este serviço é obrigatório
+        $writer->writeElement('codigo_servico_adicional', ServicoAdicional::SERVICE_REGISTRO);
+
+        foreach ($servicosAdicionais as $servicoAdicional) {
+            if ($servicoAdicional->getCodigoServicoAdicional() != ServicoAdicional::SERVICE_REGISTRO) {
+                $writer->writeElement('codigo_servico_adicional', $servicoAdicional->getCodigoServicoAdicional());
+                $valorDeclarado = (float)$servicoAdicional->getValorDeclarado();
+                if ($valorDeclarado>0) {
+                    $writer->writeElement('valor_declarado', (float)$servicoAdicional->getValorDeclarado());
+                }
+            }
+        }
+        $writer->endElement();
+    }
+
+    private function writeDimensaoObjeto(\XMLWriter $writer, Dimensao $dimensao)
+    {
+        $writer->startElement('dimensao_objeto');
+        $writer->writeElement('tipo_objeto', $dimensao->getTipo());
+        $writer->writeElement('dimensao_altura', $dimensao->getAltura());
+        $writer->writeElement('dimensao_largura', $dimensao->getLargura());
+        $writer->writeElement('dimensao_comprimento', $dimensao->getComprimento());
+        if (!$dimensao->getDiametro()) {
+            $writer->writeElement('dimensao_diametro', 0);
+        } else {
+            $writer->writeElement('dimensao_diametro', $dimensao->getDiametro());
+        }
+        $writer->endElement();
+    }
+}

--- a/tests/BootstrapTrait.php
+++ b/tests/BootstrapTrait.php
@@ -2,17 +2,16 @@
 
 namespace PhpSigep\Test;
 
+use PhpSigep\Config;
+
 trait BootstrapTrait
 {
     public function setUpSIGEP(): void
     {
         $config = new \PhpSigep\Config();
-
         $config->setAccessData(new \PhpSigep\Model\AccessDataHomologacao());
-
         $config->setEnv(\PhpSigep\Config::ENV_DEVELOPMENT);
-
-
+        $config->setXmlEncode(Config::XML_ENCODE_UTF);
         $config->setCacheOptions(array(
             'storageOptions' => array(
                 'enabled' => false,

--- a/tests/Builders/PreListaDePostagemBuilder.php
+++ b/tests/Builders/PreListaDePostagemBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PhpSigep\Test\Builders;
+
+class PreListaDePostagemBuilder
+{
+    /**
+     * @return \PhpSigep\Model\PreListaDePostagem
+     */
+    public static function buildDadosObrigatorios()
+    {
+        $dimensao = new \PhpSigep\Model\Dimensao();
+        $dimensao->setAltura(20);
+        $dimensao->setLargura(20);
+        $dimensao->setComprimento(20);
+        $dimensao->setDiametro(0);
+        $dimensao->setTipo(\PhpSigep\Model\Dimensao::TIPO_PACOTE_CAIXA);
+
+        $destinatario = new \PhpSigep\Model\Destinatario();
+        $destinatario->setNome('Google Belo Horizonte');
+        $destinatario->setLogradouro('Av. Bias Fortes');
+        $destinatario->setNumero('382');
+        $destinatario->setComplemento('6º andar');
+
+        $destino = new \PhpSigep\Model\DestinoNacional();
+        $destino->setBairro('Lourdes');
+        $destino->setCep('30170-010');
+        $destino->setCidade('Belo Horizonte');
+        $destino->setUf('MG');
+
+        // Estamos criando uma etique falsa, mas em um ambiente real voçê deve usar o método
+        // {@link \PhpSigep\Services\SoapClient\Real::solicitaEtiquetas() } para gerar o número das etiquetas
+        $etiqueta = new \PhpSigep\Model\Etiqueta();
+        $etiqueta->setEtiquetaSemDv('PD73958096BR');
+
+        $servicoAdicional = new \PhpSigep\Model\ServicoAdicional();
+        $servicoAdicional->setCodigoServicoAdicional(\PhpSigep\Model\ServicoAdicional::SERVICE_REGISTRO);
+        // Se não tiver valor declarado informar 0 (zero)
+        $servicoAdicional->setValorDeclarado(0);
+
+        $encomenda = new \PhpSigep\Model\ObjetoPostal();
+        $encomenda->setServicosAdicionais([$servicoAdicional]);
+        $encomenda->setDestinatario($destinatario);
+        $encomenda->setDestino($destino);
+        $encomenda->setDimensao($dimensao);
+        $encomenda->setEtiqueta($etiqueta);
+        $encomenda->setPeso(0.500);// 500 gramas
+        $encomenda->setServicoDePostagem(new \PhpSigep\Model\ServicoDePostagem(\PhpSigep\Model\ServicoDePostagem::SERVICE_SEDEX_41556));
+// ***  FIM DOS DADOS DA ENCOMENDA QUE SERÁ DESPACHADA *** //
+
+// *** DADOS DO REMETENTE *** //
+        $remetente = new \PhpSigep\Model\Remetente();
+        $remetente->setNome('Google São Paulo');
+        $remetente->setLogradouro('Av. Brigadeiro Faria Lima');
+        $remetente->setNumero('3900');
+        $remetente->setComplemento('5º andar');
+        $remetente->setBairro('Itaim');
+        $remetente->setCep('04538-132');
+        $remetente->setUf('SP');
+        $remetente->setCidade('São Paulo');
+// *** FIM DOS DADOS DO REMETENTE *** //
+
+
+        $plp = new \PhpSigep\Model\PreListaDePostagem();
+        $plp->setAccessData(new \PhpSigep\Model\AccessDataHomologacao());
+        $plp->setEncomendas([$encomenda]);
+        $plp->setRemetente($remetente);
+
+        return $plp;
+    }
+}

--- a/tests/Fakes/SoapClientFake.php
+++ b/tests/Fakes/SoapClientFake.php
@@ -6,6 +6,13 @@ use PhpSigep\Config;
 
 class SoapClientFake extends \SoapClient
 {
+    /**
+     * @var array
+     */
+    private $soapArgs = [];
+
+    private $retornos = [];
+
     public function __construct()
     {
         parent::__construct(Config::WSDL_ATENDE_CLIENTE_DEVELOPMENT);
@@ -13,12 +20,29 @@ class SoapClientFake extends \SoapClient
 
     public function solicitaEtiquetas(array $soapArgs): \stdClass
     {
+        $this->soapArgs = $soapArgs;
         $qtdEtiquetas = $soapArgs['qtdEtiquetas'];
 
         $codigos[] = 'SI0000000001BR';
         $codigos[] = 'SI' . sprintf('%010d', $qtdEtiquetas) . 'BR';
 
         return (object)['return' => implode(',', $codigos)];
+    }
+
+    public function fechaPlpVariosServicos(array $soapArgs): \stdClass
+    {
+        $this->soapArgs = $soapArgs;
+        return $this->retornos['fechaPlpVariosServicos'] ?? (object)['return' => '20563504'];
+    }
+
+    public function setRetornoFechaPlpVariosServicos(\stdClass $retorno)
+    {
+        $this->retornos['fechaPlpVariosServicos'] = $retorno;
+    }
+
+    public function getSoapArgs(): array
+    {
+        return $this->soapArgs;
     }
 
     public function buscaCliente(array $soapArgs): \stdClass

--- a/tests/PhpSigep/Services/Real/FecharPreListaDePostagemTest.php
+++ b/tests/PhpSigep/Services/Real/FecharPreListaDePostagemTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpSigep\Test\PhpSigep\Services\Real;
+
+use PhpSigep\Services\Real\FecharPreListaDePostagem;
+use PhpSigep\Services\Real\SoapClientFactory;
+use PhpSigep\Test\BootstrapTrait;
+use PhpSigep\Test\Builders\PreListaDePostagemBuilder;
+use PhpSigep\Test\Fakes\SoapClientFake;
+use PHPUnit\Framework\TestCase;
+
+class FecharPreListaDePostagemTest extends TestCase
+{
+    use BootstrapTrait;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpSIGEP();
+    }
+
+    public function test_execute(): void
+    {
+        $client = new SoapClientFake();
+        $std = new \stdClass();
+        $std->return = '123456';
+        $client->setRetornoFechaPlpVariosServicos($std);
+        SoapClientFactory::setSoapClient($client);
+
+        $fechar = new FecharPreListaDePostagem();
+        $retorno = $fechar->execute(PreListaDePostagemBuilder::buildDadosObrigatorios());
+
+        /** @var \PhpSigep\Model\FechaPlpVariosServicosRetorno $result */
+        $result = $retorno->getResult();
+        $this->assertEquals('123456', $result->getIdPlp());
+    }
+}

--- a/tests/PhpSigep/Services/Real/FecharPreListaDePostagemTest.php
+++ b/tests/PhpSigep/Services/Real/FecharPreListaDePostagemTest.php
@@ -27,10 +27,19 @@ class FecharPreListaDePostagemTest extends TestCase
         SoapClientFactory::setSoapClient($client);
 
         $fechar = new FecharPreListaDePostagem();
-        $retorno = $fechar->execute(PreListaDePostagemBuilder::buildDadosObrigatorios());
+        $plp = PreListaDePostagemBuilder::buildDadosObrigatorios();
+        $retorno = $fechar->execute($plp);
 
         /** @var \PhpSigep\Model\FechaPlpVariosServicosRetorno $result */
         $result = $retorno->getResult();
         $this->assertEquals('123456', $result->getIdPlp());
+        $args = $client->getSoapArgs();
+        $this->assertEquals(['xml', 'idPlpCliente', 'cartaoPostagem', 'listaEtiquetas', 'usuario', 'senha'], array_keys($args));
+        $this->assertIsString($args['xml']);
+        $this->assertEquals('', $args['idPlpCliente']);
+        $this->assertEquals($plp->getAccessData()->getCartaoPostagem(), $args['cartaoPostagem']);
+        $this->assertEquals(['PD73958096BR'], $args['listaEtiquetas']);
+        $this->assertEquals($plp->getAccessData()->getUsuario(), $args['usuario']);
+        $this->assertEquals($plp->getAccessData()->getSenha(), $args['senha']);
     }
 }

--- a/tests/PhpSigep/Services/Real/PreListaDePostagem/GerarXmlPreListaDePostagemTest.php
+++ b/tests/PhpSigep/Services/Real/PreListaDePostagem/GerarXmlPreListaDePostagemTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpSigep\Test\PhpSigep\Services\Real\PreListaDePostagem;
+
+use PhpSigep\Services\Real\PreListaDePostagem\GerarXmlPreListaDePostagem;
+use PhpSigep\Test\BootstrapTrait;
+use PhpSigep\Test\Builders\PreListaDePostagemBuilder;
+use PhpSigep\Test\Xml\Util;
+use PHPUnit\Framework\TestCase;
+
+class GerarXmlPreListaDePostagemTest extends TestCase
+{
+    use BootstrapTrait;
+
+    public function setUp(): void
+    {
+        $this->setUpSIGEP();
+    }
+
+    public function test_gerar_daos_obrigatorios(): void
+    {
+        $plp = PreListaDePostagemBuilder::buildDadosObrigatorios();
+        $gerarXml = new GerarXmlPreListaDePostagem();
+        $xml = Util::normalizeXmlForTest($gerarXml->gerar($plp));
+        $xmlEsperado = Util::normalizeXmlForTest(file_get_contents(dirname(__DIR__, 4) . '/resources/xml/modelo_plp1-utf8.xml'));
+        $this->assertEquals($xmlEsperado, $xml);
+    }
+}

--- a/tests/Xml/Util.php
+++ b/tests/Xml/Util.php
@@ -4,26 +4,6 @@ namespace PhpSigep\Test\Xml;
 
 class Util
 {
-    /**
-     * @param string $xml
-     * @return string
-     */
-    public static function removeWhiteSpaces(string $xml)
-    {
-        $obj = simplexml_load_string($xml, null, LIBXML_NOBLANKS);
-
-        return str_replace("\n", "", $obj->asXML());
-    }
-
-    /**
-     * @param string $path
-     * @return string
-     */
-    public static function removeWhiteSpacesFromPath(string $path)
-    {
-        return self::removeWhiteSpaces(file_get_contents($path));
-    }
-
     public static function normalizeXmlForTest(string $xml): string
     {
         $dom = new \DOMDocument();

--- a/tests/Xml/Util.php
+++ b/tests/Xml/Util.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpSigep\Test\Xml;
+
+class Util
+{
+    /**
+     * @param string $xml
+     * @return string
+     */
+    public static function removeWhiteSpaces(string $xml)
+    {
+        $obj = simplexml_load_string($xml, null, LIBXML_NOBLANKS);
+
+        return str_replace("\n", "", $obj->asXML());
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    public static function removeWhiteSpacesFromPath(string $path)
+    {
+        return self::removeWhiteSpaces(file_get_contents($path));
+    }
+
+    public static function normalizeXmlForTest(string $xml): string
+    {
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML($xml);
+        return $dom->saveXML();
+    }
+}

--- a/tests/resources/xml/modelo_plp1-utf8.xml
+++ b/tests/resources/xml/modelo_plp1-utf8.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<correioslog>
+    <tipo_arquivo>Postagem</tipo_arquivo>
+    <versao_arquivo>2.3</versao_arquivo>
+    <plp>
+        <id_plp/>
+        <valor_global/>
+        <mcu_unidade_postagem/>
+        <nome_unidade_postagem/>
+        <cartao_postagem>0067599079</cartao_postagem>
+    </plp>
+    <remetente>
+        <numero_contrato>9992157880</numero_contrato>
+        <numero_diretoria>10</numero_diretoria>
+        <codigo_administrativo>17000190</codigo_administrativo>
+        <nome_remetente><![CDATA[Google São Paulo]]></nome_remetente>
+        <logradouro_remetente><![CDATA[Av. Brigadeiro Faria Lima]]></logradouro_remetente>
+        <numero_remetente><![CDATA[3900]]></numero_remetente>
+        <complemento_remetente><![CDATA[5º andar]]></complemento_remetente>
+        <bairro_remetente><![CDATA[Itaim]]></bairro_remetente>
+        <cep_remetente><![CDATA[04538132]]></cep_remetente>
+        <cidade_remetente><![CDATA[São Paulo]]></cidade_remetente>
+        <uf_remetente>SP</uf_remetente>
+        <telefone_remetente><![CDATA[]]></telefone_remetente>
+        <fax_remetente><![CDATA[]]></fax_remetente>
+        <email_remetente><![CDATA[]]></email_remetente>
+        <celular_remetente><![CDATA[]]></celular_remetente>
+        <cpf_cnpj_remetente><![CDATA[]]></cpf_cnpj_remetente>
+        <ciencia_conteudo_proibido>S</ciencia_conteudo_proibido>
+    </remetente>
+    <forma_pagamento/>
+    <objeto_postal>
+        <numero_etiqueta>PD739580968BR</numero_etiqueta>
+        <codigo_objeto_cliente/>
+        <codigo_servico_postagem>41556</codigo_servico_postagem>
+        <cubagem>0</cubagem>
+        <peso>500</peso>
+        <rt1/>
+        <rt2/>
+        <restricao_anac>0</restricao_anac>
+        <destinatario>
+            <nome_destinatario><![CDATA[Google Belo Horizonte]]></nome_destinatario>
+            <telefone_destinatario><![CDATA[]]></telefone_destinatario>
+            <celular_destinatario><![CDATA[]]></celular_destinatario>
+            <email_destinatario><![CDATA[]]></email_destinatario>
+            <logradouro_destinatario><![CDATA[Av. Bias Fortes]]></logradouro_destinatario>
+            <complemento_destinatario><![CDATA[6º andar]]></complemento_destinatario>
+            <numero_end_destinatario><![CDATA[382]]></numero_end_destinatario>
+            <cpf_cnpj_destinatario><![CDATA[]]></cpf_cnpj_destinatario>
+        </destinatario>
+        <nacional>
+            <bairro_destinatario><![CDATA[Lourdes]]></bairro_destinatario>
+            <cidade_destinatario><![CDATA[Belo Horizonte]]></cidade_destinatario>
+            <uf_destinatario>MG</uf_destinatario>
+            <cep_destinatario><![CDATA[30170010]]></cep_destinatario>
+            <codigo_usuario_postal/>
+            <centro_custo_cliente/>
+            <numero_nota_fiscal/>
+            <serie_nota_fiscal></serie_nota_fiscal>
+            <valor_nota_fiscal/>
+            <natureza_nota_fiscal></natureza_nota_fiscal>
+            <descricao_objeto><![CDATA[]]></descricao_objeto>
+            <valor_a_cobrar>0</valor_a_cobrar>
+        </nacional>
+        <servico_adicional>
+            <codigo_servico_adicional>025</codigo_servico_adicional>
+        </servico_adicional>
+        <dimensao_objeto>
+            <tipo_objeto>002</tipo_objeto>
+            <dimensao_altura>20</dimensao_altura>
+            <dimensao_largura>20</dimensao_largura>
+            <dimensao_comprimento>20</dimensao_comprimento>
+            <dimensao_diametro>0</dimensao_diametro>
+        </dimensao_objeto>
+        <data_postagem_sara/>
+        <status_processamento>0</status_processamento>
+        <numero_comprovante_postagem/>
+        <valor_cobrado/>
+    </objeto_postal>
+</correioslog>


### PR DESCRIPTION
No geral são melhorias para com php 8.1, onde tive os warnings na imagem abaixo. Porém como não haviam testes automatizados para garantir que minha alteração funciona, tive que mexer em mais arquivos... Se o PR estiver muito grande posso tentar quebrar em mais.

- Removi campo referencia e sms, pois não vi uso para elas. Não são incluídas no xml
- em `PhpSigep\Model\Destinatario` e `PhpSigep\Model\Remetente` corrigi o php doc dos atributos, os opcionais aceitam null
- extraí uma classe de `src/PhpSigep/Services/Real/FecharPreListaDePostagem.php`, isolei a parte que monta o xml para facilitar os testes automatizados e diminuir responsabilidades da classe. A classe responsável por gerar o xml é a `src/PhpSigep/Services/Real/PreListaDePostagem/GerarXmlPreListaDePostagem.php`
- Criei um teste para certificar que o xml está sendo gerado corretamente
- Criei um teste para verificar se o fechamento da PLP continua ocorrendo e retornando a lista de etiquetas

![image](https://user-images.githubusercontent.com/293154/167219061-115150d7-2dd9-4498-9686-ec67491712e8.png)
