### PR TITLE
Adição dos campos de "destino" e "endereco" em rastrear Objeto e adição da classe RastrearObjetoLista

### DIFF
--- a/src/PhpSigep/Model/RastrearObjetoEvento.php
+++ b/src/PhpSigep/Model/RastrearObjetoEvento.php
@@ -4,6 +4,7 @@ namespace PhpSigep\Model;
 /**
  * @author: Stavarengo
  * @author: davidalves1
+ * @author: rodrigojob
  */
 class RastrearObjetoEvento extends AbstractModel
 {
@@ -43,6 +44,14 @@ class RastrearObjetoEvento extends AbstractModel
      * @var string
      */
     protected $cidade;
+    /**
+     * @var array
+     */
+    protected $destino;
+    /**
+     * @var array
+     */
+    protected $endereco;
     /**
      * @var string
      */
@@ -223,6 +232,45 @@ class RastrearObjetoEvento extends AbstractModel
         return $this->cidade;
     }
 
+    /**
+     * @param array $endereco
+     * @return $this;
+     */
+    public function setEndereco($endereco)
+    {
+        $this->endereco = $endereco;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEndereco()
+    {
+        return $this->endereco;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getDestino()
+    {
+        return $this->destino;
+    }
+
+
+    /**
+     * @param array $destino
+     * @return $this;
+     */
+    public function setDestino($destino)
+    {
+        $this->destino = $destino;
+
+        return $this;
+    }
 
     /**
      * @param string $uf

--- a/src/PhpSigep/Services/Real/RastrearObjeto.php
+++ b/src/PhpSigep/Services/Real/RastrearObjeto.php
@@ -13,6 +13,7 @@ use Symfony\Polyfill\Php56\Php56;
 /**
  * @author: Stavarengo
  * @author: davidalves1
+ * @author: rodrigojob  (eConector)
  */
 class RastrearObjeto
 {
@@ -130,6 +131,8 @@ class RastrearObjeto
                                 $evento->setCodigo($ev->codigo);
                                 $evento->setCidade(isset($ev->cidade) ? $ev->cidade : '');
                                 $evento->setUf(isset($ev->uf) ? $ev->uf : '');
+                                $evento->setDestino($ev->destino);
+                                $evento->setEndereco($ev->endereco);
 
                                 // Sempre adiciona o recebedor ao resultado, mesmo ele sendo exibido apenas quanto 'tipo' = BDE e 'status' = 01
                                 $evento->setRecebedor(

--- a/src/PhpSigep/Services/Real/RastrearObjetoLista.php
+++ b/src/PhpSigep/Services/Real/RastrearObjetoLista.php
@@ -1,0 +1,171 @@
+<?php
+namespace PhpSigep\Services\Real;
+
+use PhpSigep\Model\Etiqueta;
+use PhpSigep\Model\RastrearObjetoEvento;
+use PhpSigep\Model\RastrearObjetoResultado;
+use PhpSigep\Services\Real\Exception\RastrearObjeto\ExibirErrosException;
+use PhpSigep\Services\Real\Exception\RastrearObjeto\RastrearObjetoException;
+use PhpSigep\Services\Real\Exception\RastrearObjeto\TipoInvalidoException;
+use PhpSigep\Services\Result;
+use Symfony\Polyfill\Php56\Php56;
+
+/**
+ * @author: rodrigojob  (eConector)
+ */
+class RastrearObjetoLista
+{
+
+    /**
+     * @param \PhpSigep\Model\RastrearObjeto $params
+     * @return \PhpSigep\Services\Result<\PhpSigep\Model\RastrearObjetoResultado[]>
+     * @throws Exception\RastrearObjeto\TipoResultadoInvalidoException
+     * @throws Exception\RastrearObjeto\TipoInvalidoException
+     */
+    public function execute(\PhpSigep\Model\RastrearObjeto $params)
+    {
+        switch ($params->getTipo()) {
+            case \PhpSigep\Model\RastrearObjeto::TIPO_LISTA_DE_OBJETOS:
+                $tipo = 'L';
+                break;
+            case \PhpSigep\Model\RastrearObjeto::TIPO_INTERVALO_DE_OBJETOS:
+                $tipo = 'F';
+                break;
+            default:
+                throw new \PhpSigep\Services\Real\Exception\RastrearObjeto\TipoInvalidoException("Tipo '" . $params->getTipo(
+                    ) . "' não é valido");
+                break;
+        }
+        switch ($params->getTipoResultado()) {
+            case \PhpSigep\Model\RastrearObjeto::TIPO_RESULTADO_APENAS_O_ULTIMO_EVENTO:
+                $tipoResultado = 'U';
+                break;
+            case \PhpSigep\Model\RastrearObjeto::TIPO_RESULTADO_TODOS_OS_EVENTOS:
+                $tipoResultado = 'T';
+                break;
+            default:
+                throw new \PhpSigep\Services\Real\Exception\RastrearObjeto\TipoResultadoInvalidoException("Tipo de resultado '" . $params->getTipo(
+                    ) . "' não é valido");
+                break;
+        }
+
+        switch ($params->getExibirErros()) {
+            case \PhpSigep\Model\RastrearObjeto::EXIBIR_RESULTADOS_COM_ERRO:
+                $exibir_erro = true;
+                break;
+            case \PhpSigep\Model\RastrearObjeto::ESCONDER_RESULTADOS_COM_ERRO:
+                $exibir_erro = false;
+                break;
+            default:
+                throw new TipoInvalidoException("Tipo '" . $params->getExibirErros(
+                    ) . "' não é válido para esta opção'");
+        }
+
+        $soapArgs = array(
+            'usuario'   => $params->getAccessData()->getUsuario(),
+            'senha'     => $params->getAccessData()->getSenha(),
+            'tipo'      => $tipo,
+            'resultado' => $tipoResultado,
+            'lingua' => $params->getIdioma(),
+            'objetos'    =>  array_map(
+                    function (\PhpSigep\Model\Etiqueta $etiqueta) {
+                        return $etiqueta->getEtiquetaComDv();
+                    },
+                    $params->getEtiquetas()
+                
+                            ),
+        );
+
+        $result = new Result();
+
+        try {
+            $soapReturn = SoapClientFactory::getRastreioObjetos()->buscaEventosLista($soapArgs);
+
+            if ($soapReturn && is_object($soapReturn) && $soapReturn->return) {
+
+                try {
+                    if (!is_array($soapReturn->return->objeto)) {
+
+                        $soapReturn->return->objeto = array($soapReturn->return->objeto);
+                    }
+
+                    $resultado = array();
+
+                    foreach ($soapReturn->return->objeto as $objeto) {
+
+                        $eventos = new RastrearObjetoResultado();
+                        $eventos->setEtiqueta(new Etiqueta(array('etiquetaComDv' => $objeto->numero)));
+
+                        // Verifica se ocorreu algum erro ao consultar a etiqueta
+                        if (isset($objeto->erro)) {
+                            // Se estiver configurado para não exibir erros, não insere os resultados com erros
+                            if (!$exibir_erro) {
+                                continue;
+                            }
+
+                            $evento = new RastrearObjetoEvento();
+
+                            $evento->setError(SoapClientFactory::convertEncoding('(' . $objeto->numero . ') ' . $objeto->erro));
+
+                            // Adiciona o evento ao resultado
+                            $eventos->addEvento($evento);
+
+                        } else {
+
+                            if (!is_array($objeto->evento))
+                                $objeto->evento = array($objeto->evento);
+
+                            foreach ($objeto->evento as $ev) {
+
+                                $evento = new RastrearObjetoEvento();
+                                $evento->setTipo($ev->tipo);
+                                $evento->setStatus($ev->status);
+                                $evento->setDataHora(\DateTime::createFromFormat('d/m/Y H:i', $ev->data . ' ' . $ev->hora));
+                                $evento->setDescricao(SoapClientFactory::convertEncoding($ev->descricao));
+                                $evento->setDetalhe(SoapClientFactory::convertEncoding(isset($ev->detalhe) ? $ev->detalhe : ''));
+                                $evento->setLocal($ev->local);
+                                $evento->setCodigo($ev->codigo);
+                                $evento->setCidade(isset($ev->cidade) ? $ev->cidade : '');
+                                $evento->setUf(isset($ev->uf) ? $ev->uf : '');
+                                $evento->setEndereco($ev->endereco);
+                                $evento->setDestino($ev->destino);
+
+                                // Sempre adiciona o recebedor ao resultado, mesmo ele sendo exibido apenas quanto 'tipo' = BDE e 'status' = 01
+                                $evento->setRecebedor(
+                                    isset($ev->recebedor) && !empty($ev->recebedor) ? trim($ev->recebedor) : ''
+                                );
+
+                                // Adiciona o evento ao resultado
+                                $eventos->addEvento($evento);
+                            }
+                        }
+
+                        $resultado[] = $eventos;
+                    }
+
+                    $result->setResult($resultado);
+
+                } catch (RastrearObjetoException $e) {
+                    $result->setErrorCode(0);
+                    $result->setErrorMsg("Erro de comunicação com o Correios ao tentar buscar os dados de rastreamento. Detalhes: " . $e->getMessage());
+                }
+
+            } else {
+                $result->setErrorCode(0);
+                $result->setErrorMsg('A resposta do Correios não está no formato esperado. Resposta recebida: "' .
+                    $soapReturn . '"');
+            }
+        } catch (\Exception $e) {
+            if ($e instanceof \SoapFault) {
+                $result->setIsSoapFault(true);
+                $result->setErrorCode($e->getCode());
+                $result->setErrorMsg(SoapClientFactory::convertEncoding($e->getMessage()));
+            } else {
+                $result->setErrorCode($e->getCode());
+                $result->setErrorMsg($e->getMessage() . ' - ' . $e->getLine());
+            }
+        }
+        
+        return $result;
+    }
+}

--- a/src/PhpSigep/Services/SoapClient/Real.php
+++ b/src/PhpSigep/Services/SoapClient/Real.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PhpSigep\Services\SoapClient;
 
 use PhpSigep\Model\BuscaClienteResult;
@@ -9,16 +10,16 @@ use VRia\Utils\NoDiacritic;
 
 /**
  * @author: Stavarengo
+ * @author: rodrigojob
  */
-class Real implements ServiceInterface
-{
+class Real implements ServiceInterface {
+
     /**
      * @param \PhpSigep\Model\VerificaDisponibilidadeServico $params
      *
      * @return Result<\PhpSigep\Model\VerificaDisponibilidadeServicoResposta>
      */
-    public function verificaDisponibilidadeServico(\PhpSigep\Model\VerificaDisponibilidadeServico $params)
-    {
+    public function verificaDisponibilidadeServico(\PhpSigep\Model\VerificaDisponibilidadeServico $params) {
         $service = new ServiceImplementation\VerificaDisponibilidadeServico();
         return $service->execute($params);
     }
@@ -28,8 +29,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\SolicitarPostagemReversaRetorno>
      */
-    public function solicitarPostagemReversa(\PhpSigep\Model\SolicitarPostagemReversa $params)
-    {
+    public function solicitarPostagemReversa(\PhpSigep\Model\SolicitarPostagemReversa $params) {
         $service = new ServiceImplementation\SolicitarPostagemReversa();
         return $service->execute($params);
     }
@@ -39,8 +39,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\ConsultaCepResposta>
      */
-    public function consultaCep($cep)
-    {
+    public function consultaCep($cep) {
         $service = new ServiceImplementation\ConsultaCep();
         return $service->execute($cep);
     }
@@ -50,8 +49,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\Etiqueta[]>
      */
-    public function solicitaEtiquetas(\PhpSigep\Model\SolicitaEtiquetas $params)
-    {
+    public function solicitaEtiquetas(\PhpSigep\Model\SolicitaEtiquetas $params) {
         $service = new ServiceImplementation\SolicitaEtiquetas();
         return $service->execute($params);
     }
@@ -61,8 +59,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\solicitaXmlPlp[]>
      */
-    public function solicitaXmlPlp($idPlpMaster)
-    {
+    public function solicitaXmlPlp($idPlpMaster) {
         $service = new ServiceImplementation\SolicitaXmlPlp();
 
         return $service->execute($idPlpMaster);
@@ -75,8 +72,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\ListarAgenciasCliqueRetireResult[]>
      */
-    public function listarAgenciasCliqueRetire($zone, $city, $address_2)
-    {
+    public function listarAgenciasCliqueRetire($zone, $city, $address_2) {
         $service = new ServiceImplementation\ListarAgenciasCliqueRetire();
 
         return $service->execute($zone, $city, $address_2);
@@ -86,8 +82,7 @@ class Real implements ServiceInterface
      * @param string $cep
      * @return Result<\PhpSigep\Model\ListarAgenciasCliqueRetireResult[]>|Result<\PhpSigep\Model\ConsultaCepResposta>
      */
-    public function listarAgenciasCliqueRetireByCep($cep)
-    {
+    public function listarAgenciasCliqueRetireByCep($cep) {
         $result = $this->consultaCep($cep);
         if ($result->hasError()) {
             return $result;
@@ -106,8 +101,7 @@ class Real implements ServiceInterface
      *
      * @return Result<\PhpSigep\Model\ConsultarAgenciaResult[]>
      */
-    public function consultarAgencia($codigo)
-    {
+    public function consultarAgencia($codigo) {
         $service = new ServiceImplementation\ConsultarAgencia();
 
         return $service->execute($codigo);
@@ -116,7 +110,7 @@ class Real implements ServiceInterface
     /**
      * Pede para o WebService do Correios calcular o dígito verificador de uma etiqueta.
      *
-     * Se preferir você pode usar o método {@linnk \PhpSigep\Model\Etiqueta::getDv() } para calcular o dígito
+     * Se preferir você pode usar o método {@link \PhpSigep\Model\Etiqueta::getDv() } para calcular o dígito
      * verificador, visto que esse método é mais rápido pois faz o cálculo local sem precisar se comunicar com o
      * WebService.
      *
@@ -125,8 +119,7 @@ class Real implements ServiceInterface
      * @throws \Exception
      * @return Result
      */
-    public function geraDigitoVerificadorEtiquetas(\PhpSigep\Model\GeraDigitoVerificadorEtiquetas $params)
-    {
+    public function geraDigitoVerificadorEtiquetas(\PhpSigep\Model\GeraDigitoVerificadorEtiquetas $params) {
         $service = new ServiceImplementation\GeraDigitoVerificadorEtiquetas();
         return $service->execute($params);
     }
@@ -135,8 +128,7 @@ class Real implements ServiceInterface
      * @param \PhpSigep\Model\PreListaDePostagem $params
      * @return Result<\PhpSigep\Model\FechaPlpVariosServicosRetorno>
      */
-    public function fechaPlpVariosServicos(\PhpSigep\Model\PreListaDePostagem $params)
-    {
+    public function fechaPlpVariosServicos(\PhpSigep\Model\PreListaDePostagem $params) {
         $service = new ServiceImplementation\FecharPreListaDePostagem();
         return $service->execute($params);
     }
@@ -145,8 +137,7 @@ class Real implements ServiceInterface
      * @param \PhpSigep\Model\CalcPrecoPrazo $params
      * @return Result<\PhpSigep\Model\CalcPrecoPrazoResposta[]>
      */
-    public function calcPrecoPrazo(\PhpSigep\Model\CalcPrecoPrazo $params)
-    {
+    public function calcPrecoPrazo(\PhpSigep\Model\CalcPrecoPrazo $params) {
         $service = new ServiceImplementation\CalcPrecoPrazo();
         return $service->execute($params);
     }
@@ -157,8 +148,7 @@ class Real implements ServiceInterface
      * @param \PhpSigep\Model\AccessData $params
      * @return Result<BuscaClienteResult>
      */
-    public function buscaCliente(\PhpSigep\Model\AccessData $params)
-    {
+    public function buscaCliente(\PhpSigep\Model\AccessData $params) {
         $service = new ServiceImplementation\BuscaCliente();
         return $service->execute($params);
     }
@@ -168,9 +158,20 @@ class Real implements ServiceInterface
      * @param \PhpSigep\Model\RastrearObjeto $params
      * @return Result<\PhpSigep\Model\RastrearObjetoResultado[]>
      */
-    public function rastrearObjeto(\PhpSigep\Model\RastrearObjeto $params)
-    {
+    public function rastrearObjeto(\PhpSigep\Model\RastrearObjeto $params) {
+        
         $service = new ServiceImplementation\RastrearObjeto();
+        return $service->execute($params);
+    }
+
+    /**
+     *
+     * @param \PhpSigep\Model\RastrearObjeto $params
+     * @return Result<\PhpSigep\Model\RastrearObjetoResultado[]>
+     */
+    public function rastrearObjetoLista(\PhpSigep\Model\RastrearObjeto $params) {
+        
+        $service = new ServiceImplementation\RastrearObjetoLista();
         return $service->execute($params);
     }
 
@@ -180,8 +181,7 @@ class Real implements ServiceInterface
      * @param $senha
      * @return Result<\PhpSigep\Model\verificarStatusCartaoPostagemResposta[]>
      */
-    public function verificarStatusCartaoPostagem($numeroCartaoPostagem, $usuario, $senha)
-    {
+    public function verificarStatusCartaoPostagem($numeroCartaoPostagem, $usuario, $senha) {
         $service = new ServiceImplementation\VerificarStatusCartaoPostagem();
         return $service->execute($numeroCartaoPostagem, $usuario, $senha);
     }
@@ -194,8 +194,7 @@ class Real implements ServiceInterface
      * @param $senha
      * @return Result<\PhpSigep\Model\BloquearObjetoResposta[]>
      */
-    public function bloquearObjeto($numeroEtiqueta, $idPlp, $usuario, $senha)
-    {
+    public function bloquearObjeto($numeroEtiqueta, $idPlp, $usuario, $senha) {
         $service = new ServiceImplementation\BloquearObjeto();
         return $service->execute($numeroEtiqueta, $idPlp, $usuario, $senha);
     }
@@ -208,30 +207,26 @@ class Real implements ServiceInterface
      * @param $senha
      * @return Result<\PhpSigep\Model\CancelarObjetoResposta[]>
      */
-    public function cancelarObjeto($numeroEtiqueta, $idPlp, $usuario, $senha)
-    {
+    public function cancelarObjeto($numeroEtiqueta, $idPlp, $usuario, $senha) {
         $service = new ServiceImplementation\CancelarObjeto();
         return $service->execute($numeroEtiqueta, $idPlp, $usuario, $senha);
     }
 
     /**
      * @param \PhpSigep\Model\PedidoInformacao $params
-     *
      * @return $pedido
      */
-    public function cadastrarPi(\PhpSigep\Model\PedidoInformacao $params)
-    {
+    public function cadastrarPi(\PhpSigep\Model\PedidoInformacao $params) {
         $service = new ServiceImplementation\CadastrarPI();
         return $service->execute($params);
     }
 
-
     /**
      * @param \PhpSigep\Model\ConsultarColeta $params
      */
-    public function consultaColeta(\PhpSigep\Model\ConsultarColeta $params)
-    {
+    public function consultaColeta(\PhpSigep\Model\ConsultarColeta $params) {
         $service = new ServiceImplementation\ConsultarColeta();
         return $service->execute($params);
     }
+
 }

--- a/src/PhpSigep/Services/SoapClient/Real.php
+++ b/src/PhpSigep/Services/SoapClient/Real.php
@@ -10,7 +10,7 @@ use VRia\Utils\NoDiacritic;
 
 /**
  * @author: Stavarengo
- * @author: rodrigojob
+ * @author: rodrigojob  (eConector)
  */
 class Real implements ServiceInterface {
 


### PR DESCRIPTION
O campo de destino não é tão mais útil no rastreamento, mas mostra a cidade para qual o pacote está indo, e pode ser a cidade errada.
O campo de endereço é útil para identificar onde o pacote deve ser retirado pelo destinatário, ou em caso de retorno, pelo remetente.
A classe RastrearObjetoLista permite o rastreamento de até 50 objetos por vez, agilizando o rastreamento de um volume grande de envios. Aconselho obter somente o último movimento.

Estou com problema no meu firewall e não consegui fazer o pull diretamente do netbeans, tive que alterar os arquivos manualmente. Pode ser que está faltando alguma coisa.