### PR TITLE
Adding property context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
       fail-fast: false
 
     steps:

--- a/src/PhpSigep/Pdf/ImprovedFPDF.php
+++ b/src/PhpSigep/Pdf/ImprovedFPDF.php
@@ -466,8 +466,9 @@ class ImprovedFPDF extends \PhpSigepFPDF
 
 //Stream handler to read from global variables
 class VariableStream {
-    var $position;
-    var $varname;
+    public $position;
+    public $varname;
+    public $context;
 
     function stream_open($path, $mode, $options, &$opened_path)
     {


### PR DESCRIPTION
A ideia é corrigir o seguinte warning ao executar com PHP 8.2:

`deprecated: 8192 :: Creation of dynamic property PhpSigep\Pdf\VariableStream::$context is deprecated on line 1232 of .../vendor/stavarengo/php-sigep-fpdf/fpdf.php`