### PR TITLE
Resolver Warning de LogisticaReversaPedidoResposta.php

### DIFF
--- a/src/PhpSigep/Model/LogisticaReversaPedidoResposta.php
+++ b/src/PhpSigep/Model/LogisticaReversaPedidoResposta.php
@@ -25,7 +25,7 @@ class LogisticaReversaPedidoResposta extends AbstractModel
     {
         $this->return = $return;
         
-        if (is_object($return->resultado_solicitacao)){
+        if (isset($return->resultado_solicitacao) && is_object($return->resultado_solicitacao)){
             if (sizeof((array)$return->resultado_solicitacao)>0){
                 $this->coletas_solicitadas = $return->resultado_solicitacao;
             }


### PR DESCRIPTION
Resolver o warning da linha 28 da classe LogisticaReversaPedidoResposta para quando o atributo resultado_solicitacao não existir.