### PR TITLE
Melhorando suporte a PHP 8.4

### DIFF
--- a/src/PhpSigep/Cache/Storage/Adapter/AdapterOptions.php
+++ b/src/PhpSigep/Cache/Storage/Adapter/AdapterOptions.php
@@ -49,7 +49,7 @@ class AdapterOptions extends DefaultStdClass
      * @param  StorageInterface|null $adapter
      * @return AdapterOptions
      */
-    public function setAdapter(StorageInterface $adapter = null)
+    public function setAdapter(?StorageInterface $adapter = null)
     {
         $this->adapter = $adapter;
 


### PR DESCRIPTION
Hoje ocorre o seguinte erro:
deprecated: 8192 :: PhpSigep\Cache\Storage\Adapter\AdapterOptions::setAdapter(): Implicitly marking parameter $adapter as nullable is deprecated, the explicit nullable type must be used instead on line 52